### PR TITLE
Remove insecure initialization flag

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -19,7 +19,7 @@ if [ ! -f "${CONFIG_DIR}/initialized" ]; then
 	sed -i "s:/var/log/mysql:$CONFIG_DIR:" $CONFIG_DIR/mysql.conf.d/mysqld.cnf
 	echo "log_bin_index = $CONFIG_DIR/binlog.index" >> $CONFIG_DIR/mysql.conf.d/mysqld.cnf
 
-	$SNAP/usr/sbin/mysqld --initialize-insecure --datadir=$CONFIG_DIR/data --user=snap_daemon
+	$SNAP/usr/sbin/mysqld --initialize --datadir=$CONFIG_DIR/data --user=snap_daemon
 
 	# Change ownership of snap directories to allow snap_daemon to read/write
         chown -R snap_daemon:root $SNAP_DATA


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
mysqld is initialized during the config hook with the insecure flag

* **What is the new behavior (if this is a feature change)?**
mysqld is initialized during the config hook without the insecure flag

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
N/A
