### PR TITLE
Move binlog index location

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -18,7 +18,7 @@ sed -i "s:/var/run/mysqld:$CONFIG_DIR:g" $CONFIG_DIR/mysql.conf.d/mysqld.cnf
 sed -i "s:/var/lib/mysql:$CONFIG_DIR/data:g" $CONFIG_DIR/mysql.conf.d/mysqld.cnf
 sed -i "s:/var/log/mysql:$CONFIG_DIR:g" $CONFIG_DIR/mysql.conf.d/mysqld.cnf
 sed -i "s:/etc/mysql:$CONFIG_DIR:g" $CONFIG_DIR/mysql.cnf
-echo "log_bin_index = $CONFIG_DIR/binlog.index" >> $CONFIG_DIR/mysql.conf.d/mysqld.cnf
+echo "log_bin_index = $CONFIG_DIR/data/binlog.index" >> $CONFIG_DIR/mysql.conf.d/mysqld.cnf
 echo "mysqlx_socket = $CONFIG_DIR/mysqlx.sock" >> $CONFIG_DIR/mysql.conf.d/mysqld.cnf
 
 $SNAP/usr/sbin/mysqld --initialize --datadir=$CONFIG_DIR/data --user=root


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
the binlog index location is set with a default that is causing issues with the restore fuctionality.

* **What is the new behavior (if this is a feature change)?**
Moving the binlog index to the data directory fixes the issue with restore.  

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes.  The charm will need to be tweaked.  Shayan is aware.

* **Other information**:
We should be restructuring the snap directories following the spec.  This is a quick fix for shayan.  Further changes to the snap directories should come in a PR next pulse.
