### PR TITLE
Change the setpriv group to root for mysqld

### DIFF
--- a/snap/local/start-mysqld.sh
+++ b/snap/local/start-mysqld.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/mysqld_safe --defaults-file=${SNAP_COMMON}/mysql/mysql.cnf "$@"
+  --regid root -- $SNAP/usr/bin/mysqld_safe --defaults-file=${SNAP_COMMON}/mysql/mysql.cnf "$@"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
mysqld is run with privileges dropped and the group set to `snap_daemon`.  This creates issues when trying to write files.

* **What is the new behavior (if this is a feature change)?**
mysql is now run with the gid set to `root` allowing it to write files.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
N/A
