### PR TITLE
Uncomment newly commented default config options

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -20,6 +20,8 @@ cp -r $SNAP/etc/mysql $SNAP_DATA/etc/
 
 # Replace default configuration options to work within the snap environment
 sed -i "s:# sock:sock:g" $MYSQLD_CONFIG
+sed -i "s:# datadir:datadir:g" $MYSQLD_CONFIG
+sed -i "s:# pid-file:pid-file:g" $MYSQLD_CONFIG
 sed -i "s: mysql: snap_daemon:g" $MYSQLD_CONFIG
 sed -i "s:/var/run/mysqld:$VAR_RUN:g" $MYSQLD_CONFIG
 sed -i "s:/var/lib/mysql:$VAR_LIB:g" $MYSQLD_CONFIG


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
With the 8.0.32 update, the default config with the mysql-server package changed breaking the expected default config.

* **What is the new behavior (if this is a feature change)?**
The install hook has been updated to uncomment some recently commented config options.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, there are changes that are required on the charm to reorder some of the default config cascading.

* **Other information**:
N/A