### PR TITLE
Make mysqlrouter applications work + restrict plugs and layouts for mysql applications

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,19 +1,28 @@
 #!/bin/bash
 
 SNAP_DATA=/var/snap/charmed-mysql/current
+
 MYSQL_CONFIG=$SNAP_DATA/etc/mysql/mysql.cnf
 MYSQLD_CONFIG=$SNAP_DATA/etc/mysql/mysql.conf.d/mysqld.cnf
 
-VAR_LIB=$SNAP_COMMON/var/lib/mysql
-ETC=$SNAP_DATA/etc/mysql
-VAR_RUN=$SNAP_COMMON/var/run/mysqld
-VAR_LOG=$SNAP_COMMON/var/log/mysql
+MYSQL_ETC=$SNAP_DATA/etc/mysql
+MYSQL_VAR_LIB=$SNAP_COMMON/var/lib/mysql
+MYSQL_VAR_LOG=$SNAP_COMMON/var/log/mysql
+MYSQLD_VAR_RUN=$SNAP_COMMON/var/run/mysqld
+
+MYSQL_ROUTER_ETC=$SNAP_DATA/etc/mysqlrouter
+MYSQL_ROUTER_VAR_LIB=$SNAP_COMMON/var/lib/mysqlrouter
+MYSQL_ROUTER_VAR_LOG=$SNAP_COMMON/var/log/mysqlrouter
 
 # Creating all the needed directories
-mkdir -p $VAR_LIB
-mkdir -p $ETC
-mkdir -p $VAR_RUN
-mkdir -p $VAR_LOG
+mkdir -p $MYSQL_ETC
+mkdir -p $MYSQL_VAR_LIB
+mkdir -p $MYSQL_VAR_LOG
+mkdir -p $MYSQLD_VAR_RUN
+
+mkdir -p $MYSQL_ROUTER_ETC
+mkdir -p $MYSQL_ROUTER_VAR_LIB
+mkdir -p $MYSQL_ROUTER_VAR_LOG
 
 # Copy over mysql config file
 cp -r $SNAP/etc/mysql $SNAP_DATA/etc/
@@ -23,16 +32,15 @@ sed -i "s:# sock:sock:g" $MYSQLD_CONFIG
 sed -i "s:# datadir:datadir:g" $MYSQLD_CONFIG
 sed -i "s:# pid-file:pid-file:g" $MYSQLD_CONFIG
 sed -i "s: mysql: snap_daemon:g" $MYSQLD_CONFIG
-sed -i "s:/var/run/mysqld:$VAR_RUN:g" $MYSQLD_CONFIG
-sed -i "s:/var/lib/mysql:$VAR_LIB:g" $MYSQLD_CONFIG
-sed -i "s:/var/log/mysql:$VAR_LOG:g" $MYSQLD_CONFIG
-sed -i "s:/etc/mysql:$SNAP_DATA/etc/mysql:g" $MYSQL_CONFIG
-echo "log_bin_index = $VAR_LIB/binlog.index" >> $MYSQLD_CONFIG
-echo "mysqlx_socket = $VAR_RUN/mysqlx.sock" >> $MYSQLD_CONFIG
+sed -i "s:/var/run/mysqld:$MYSQLD_VAR_RUN:g" $MYSQLD_CONFIG
+sed -i "s:/var/lib/mysql:$MYSQL_VAR_LIB:g" $MYSQLD_CONFIG
+sed -i "s:/var/log/mysql:$MYSQL_VAR_LOG:g" $MYSQLD_CONFIG
+sed -i "s:/etc/mysql:$MYSQL_ETC:g" $MYSQL_CONFIG
+echo "log_bin_index = $MYSQL_VAR_LIB/binlog.index" >> $MYSQLD_CONFIG
+echo "mysqlx_socket = $MYSQLD_VAR_RUN/mysqlx.sock" >> $MYSQLD_CONFIG
 
-$SNAP/usr/sbin/mysqld --initialize --datadir=$VAR_LIB --user=root
+$SNAP/usr/sbin/mysqld --initialize --datadir=$MYSQL_VAR_LIB --user=root
 
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root $SNAP_DATA/*
 chown -R 584788:root $SNAP_COMMON/*
-

--- a/snap/local/run-mysql-router.sh
+++ b/snap/local/run-mysql-router.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# While daemons must be run as non-sudo user, mysqlrouter --bootstrap needs to be
+# run as root as it requires setegid privileges
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid root \
+  --regid root -- $SNAP/usr/bin/mysqlrouter "$@"

--- a/snap/local/start-mysql-router.sh
+++ b/snap/local/start-mysql-router.sh
@@ -2,4 +2,4 @@
 
 # For security measures, daemons should not be run as sudo. Execute mysqlrouter as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/mysqlrouter "$@"
+  --regid root -- $SNAP/usr/bin/mysqlrouter --config $SNAP_DATA/etc/mysqlrouter/mysqlrouter.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,36 +16,33 @@ system-usernames:
 
 package-repositories:
   - type: apt
-    components: [mysql-8.0]
-    suites: [jammy]
+    components:
+      - mysql-8.0
+      - mysql-tools
+    suites:
+      - jammy
     key-id: 859BE8D7C586F538430B19C2467B942D3A79BD29
     url: http://repo.mysql.com/apt/ubuntu/
   - type: apt
-    components: [mysql-tools]
-    suites: [jammy]
-    key-id: 859BE8D7C586F538430B19C2467B942D3A79BD29
-    url: http://repo.mysql.com/apt/ubuntu/
-  - type: apt
-    components: [main]
-    suites: [jammy]
+    components:
+      - main
+    suites:
+      - jammy
     key-id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
     url: http://repo.percona.com/percona/apt
 
 layout:
   /var/lib/mysql-files:
-    bind: $SNAP_DATA/var/lib/mysql-files
-  /var/lib/mysql:
-    bind: $SNAP_DATA/var/lib/mysql
-  /var/log/mysql:
-    bind: $SNAP_DATA/var/log/mysql
-  /etc/mysql:
-    bind: $SNAP_COMMON/mysql
-  /var/mysqld:
-    bind: $SNAP_DATA/var/run/mysqld
-  /usr/lib/mysql-router:
-    symlink: $SNAP/usr/lib/mysql-router
+    bind: $SNAP_COMMON/var/lib/mysql-files
+  /usr/lib/mysqlrouter:
+    symlink: $SNAP/usr/lib/mysqlrouter
   /etc/mysqlrouter:
-    symlink: $SNAP_COMMON
+    bind: $SNAP_DATA/etc/mysqlrouter
+  /var/lib/mysqlrouter:
+    bind: $SNAP_COMMON/var/lib/mysqlrouter
+  /var/log/mysqlrouter:
+    bind: $SNAP_COMMON/var/log/mysqlrouter
+
 
 hooks:
   install:
@@ -68,16 +65,6 @@ apps:
     command: usr/bin/mysql
     plugs:
       - network
-  mysql-config-editor:
-    command: usr/bin/mysql_config_editor
-  mysqldump:
-    command: usr/bin/mysqldump
-  mysqlpump:
-    command: usr/bin/mysqlpump
-  mysqlslap:
-    command: usr/bin/mysqlslap
-  mysqladmin:
-    command: usr/bin/mysqladmin
   mysqld:
     command: start-mysqld.sh
     daemon: simple
@@ -85,32 +72,12 @@ apps:
     plugs:
       - network
       - network-bind
-  mysqldumpslow:
-    command: usr/bin/mysqldumpslow
-  mysql-ssl-rsa-setup:
-    command: usr/bin/mysql_ssl_rsa_setup
-  mysqlimport:
-    command: usr/bin/mysqlimport
-  mysql-tzinfo-to-sql:
-    command: usr/bin/mysql_tzinfo_to_sql
-  mysqlbinlog:
-    command: usr/bin/mysqlbinlog
-  mysql-migrate-keyring:
-    command: usr/bin/mysql_migrate_keyring
-  mysql-secure-installation:
-    command: usr/bin/mysql_secure_installation
-  mysql-upgrade:
-    command: usr/bin/mysql_upgrade
-  mysqlcheck:
-    command: usr/bin/mysqlcheck
-  mysqlshow:
-    command: usr/bin/mysqlshow
   mysqlsh:
     command: usr/bin/mysqlsh
     plugs:
       - network
   mysqlrouter:
-    command: start-mysql-router.sh
+    command: run-mysql-router.sh
   mysqlrouter-service:
     command: start-mysql-router.sh
     daemon: simple
@@ -118,42 +85,14 @@ apps:
     plugs:
       - network
       - network-bind
-  mysqlrouter-passwd:
-    command: usr/bin/mysqlrouter_passwd
-  mysqlrouter-keyring:
-    command: usr/bin/mysqlrouter_keyring
-  mysqlrouter-plugin-info:
-    command: usr/bin/mysqlrouter_plugin_info
   xtrabackup:
     command: usr/bin/xtrabackup
-    plugs:
-      - network
-      - removable-media
-      - home
   xbcloud:
     command: usr/bin/xbcloud
     plugs:
       - network
-      - removable-media
-      - home
-  xbcloud-osenv:
-    command: usr/bin/xbcloud_osenv
-    plugs:
-      - network
-      - removable-media
-      - home
-  xbcrypt:
-    command: usr/bin/xbcrypt
-    plugs:
-      - network
-      - removable-media
-      - home
   xbstream:
     command: usr/bin/xbstream
-    plugs:
-      - network
-      - removable-media
-      - home
   mysqld-exporter:
     command: start-mysqld-exporter.sh
     daemon: simple


### PR DESCRIPTION
[dpe-1627](https://warthogs.atlassian.net/browse/DPE-1627)

## Issue
1. There are applications in the snapcraft file that are not used in the charm(e.g. mysqldump, mysqlpump, etc). These applications might not even have the appropriate plugs to function.
2. There are layouts for mysql (`/var/lib/mysql`, `/etc/mysql`, `/var/log/mysql`, `/var/mysqld`) which are not necessary as these directory locations are conveyed to mysqld via the default config file in the install hook. Additionally, these layouts are not using the correct $SNAP_COMMON or $SNAP_DATA directories.
3. The mysqlrouter related applications do not work as expected (they cannot be used to bootstrap and run mysqlrouter)
4. The smoke test for snap daemons checks that `active` is in `snap status <snap_daemon`'s output. But this is an invalid test as it matches `inactive` as well. Also, the application tests for `mysqlrouter` and `xtrabackup` are skipped because they do not support the `--help` option.

## Solution
1. Remove the applications that are not used by the charm
2. Remove mysqld related layouts that are no longer necessary
3. Make mysqlrouter application and daemon work
- Create a script as a wrapper to run mysqlrouter (with args forwarded as is)
- Modify the daemon script to run mysqlrouter with a config file in a predetermined location (created by the preceding bootstrap command)
4. Modify smoke test to check for the actual status if the snap daemon to be `active`. Also, run the `mysqlrouter` and `xtrabackup` smoke tests with `--version` instead