### PR TITLE
Add network plug to the mysqlrouter command

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,6 +78,8 @@ apps:
       - network
   mysqlrouter:
     command: run-mysql-router.sh
+    plugs:
+      - network
   mysqlrouter-service:
     command: start-mysql-router.sh
     daemon: simple


### PR DESCRIPTION
## Issue
Currently, the mysqlrouter application does not have the `network` plug. However it needs this plug to be able to run the bootstrap command.

## Solution
Add the `network` plug to the mysqlrouter application