### PR TITLE
Create /var/run/mysqlrouter and use snap_daemon in mysqlrouter application

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -13,6 +13,7 @@ MYSQLD_VAR_RUN=$SNAP_COMMON/var/run/mysqld
 MYSQL_ROUTER_ETC=$SNAP_DATA/etc/mysqlrouter
 MYSQL_ROUTER_VAR_LIB=$SNAP_COMMON/var/lib/mysqlrouter
 MYSQL_ROUTER_VAR_LOG=$SNAP_COMMON/var/log/mysqlrouter
+MYSQL_ROUTER_VAR_RUN=$SNAP_COMMON/var/run/mysqlrouter
 
 # Creating all the needed directories
 mkdir -p $MYSQL_ETC
@@ -23,6 +24,7 @@ mkdir -p $MYSQLD_VAR_RUN
 mkdir -p $MYSQL_ROUTER_ETC
 mkdir -p $MYSQL_ROUTER_VAR_LIB
 mkdir -p $MYSQL_ROUTER_VAR_LOG
+mkdir -p $MYSQL_ROUTER_VAR_RUN
 
 # Copy over mysql config file
 cp -r $SNAP/etc/mysql $SNAP_DATA/etc/

--- a/snap/local/run-mysql-router.sh
+++ b/snap/local/run-mysql-router.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# While daemons must be run as non-sudo user, mysqlrouter --bootstrap needs to be
-# run as root as it requires setegid privileges
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid root \
+# For security measures, applications should not be run as sudo. Execute mysqlrouter as the non-sudo user: snap-daemon.
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
   --regid root -- $SNAP/usr/bin/mysqlrouter "$@"


### PR DESCRIPTION
[dpe-1628](https://warthogs.atlassian.net/browse/DPE-1628)

## Issue
1. We would like to avoid creating mysqlrouter socket files in `/tmp`. Instead we would like to create them in `$SNAP_COMMON/var/run/mysqlrouter`
2. We would like to avoid running mysqlrouter as `root`

## Solution
1. Create `$SNAP_COMMON/var/run/mysqlrouter` in the install hook
2. Run mysqlrouter as `snap_daemon`