### PR TITLE
Add slots to access mysqld and mysqlrouter socket files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,16 @@ slots:
     source:
       read:
         - $SNAP_COMMON/var/log/mysql
+  mysql-sockets:
+    interface: content
+    content: socket-directory
+    write:
+      - $SNAP_COMMON/var/run/mysqld
+  mysqlrouter-sockets:
+    interface: content
+    content: socket-directory
+    write:
+      - $SNAP_COMMON/var/run/mysqlrouter
 
 apps:
   mysql:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,11 +59,6 @@ slots:
     source:
       read:
         - $SNAP_COMMON/var/log/mysql
-  mysql-sockets:
-    interface: content
-    content: socket-directory
-    write:
-      - $SNAP_COMMON/var/run/mysqld
   mysqlrouter-sockets:
     interface: content
     content: socket-directory


### PR DESCRIPTION
## Issue
The `mysqld` and `mysqlrouter` socket files will need to be accessible by other snaps (or charms with other snaps). The `charmed-mysql` snap is strictly confined.

## Solution
Add slots for the `$SNAP_COMMON/var/run/mysqld` folder to access mysqld socket files
Add slots for the `$SNAP_COMMON/var/run/mysqlrouter` folder to access the mysqlrouter socket files