### PR TITLE
Install only mysqlsh from MySQL

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+lint:
+  name: yamllint
+  options:
+    config-data:
+      line-length: disable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,14 +17,6 @@ system-usernames:
 package-repositories:
   - type: apt
     components:
-      - mysql-8.0
-      - mysql-tools
-    suites:
-      - jammy
-    key-id: 859BE8D7C586F538430B19C2467B942D3A79BD29
-    url: http://repo.mysql.com/apt/ubuntu/
-  - type: apt
-    components:
       - main
     suites:
       - jammy
@@ -36,12 +28,16 @@ layout:
     bind: $SNAP_COMMON/var/lib/mysql-files
   /usr/lib/mysqlrouter:
     symlink: $SNAP/usr/lib/mysqlrouter
+  /usr/lib/mysql-router:
+    symlink: $SNAP/usr/lib/mysql-router
   /etc/mysqlrouter:
     bind: $SNAP_DATA/etc/mysqlrouter
   /var/lib/mysqlrouter:
     bind: $SNAP_COMMON/var/lib/mysqlrouter
   /var/log/mysqlrouter:
     bind: $SNAP_COMMON/var/log/mysqlrouter
+  /usr/lib/mysqlsh:
+    bind: $SNAP/lib/mysqlsh
 
 
 hooks:
@@ -102,12 +98,19 @@ apps:
       - network
       - network-bind
 parts:
+  package-mysql-shell:
+    plugin: dump
+    source: https://downloads.mysql.com/archives/get/p/43/file/mysql-shell-8.0.32-linux-glibc2.12-x86-64bit.tar.gz
+    organize:
+      bin: usr/bin
+      libexec: usr/libexec
+      lib: usr/lib
+      share: usr/share
   packages-deb:
     plugin: nil
     stage-packages:
       - mysql-server
       - mysql-router
-      - mysql-shell
       - percona-xtrabackup-80
       - util-linux
   wrapper:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,7 +113,6 @@ parts:
       printf "\nPackage: percona-xtrabackup-80\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
   package-mysql-shell:
     plugin: dump
-    # yamllint disable-line rule:line-length
     source: https://downloads.mysql.com/archives/get/p/43/file/mysql-shell-8.0.32-linux-glibc2.12-x86-64bit.tar.gz
     organize:
       bin: usr/bin
@@ -134,10 +133,8 @@ parts:
     source: snap/local
   mysqld-exporter:
     plugin: dump
-    # yamllint disable-line rule:line-length
     source: https://github.com/prometheus/mysqld_exporter/releases/download/v0.14.0/mysqld_exporter-0.14.0.linux-amd64.tar.gz
     source-type: tar
-    # yamllint disable-line rule:line-length
     source-checksum: sha256/c17402137a4e9745f593127f162c1003298910cb8aa7d05bee3384738de094ae
     organize:
       'mysqld_exporter': usr/bin/mysqld_exporter

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,13 @@ package-repositories:
       - main
     suites:
       - jammy
+    key-id: 630239CC130E1A7FD81A27B140976EAF437D05B5
+    url: http://security.ubuntu.com/ubuntu/
+  - type: apt
+    components:
+      - main
+    suites:
+      - jammy
     key-id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
     url: http://repo.percona.com/percona/apt
 
@@ -98,6 +105,12 @@ apps:
       - network
       - network-bind
 parts:
+  pin-mysql-apt:
+    plugin: nil
+    override-pull: |
+      printf "Package: mysql-server\nPin: version 8.0.32*\nPin-Priority: 1001\n" > /etc/apt/preferences.d/mysql
+      printf "\nPackage: mysql-router\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
+      printf "\nPackage: percona-xtrabackup-80\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
   package-mysql-shell:
     plugin: dump
     # yamllint disable-line rule:line-length
@@ -114,6 +127,8 @@ parts:
       - mysql-router
       - percona-xtrabackup-80
       - util-linux
+    after:
+      - pin-mysql-apt
   wrapper:
     plugin: dump
     source: snap/local

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,6 +100,7 @@ apps:
 parts:
   package-mysql-shell:
     plugin: dump
+    # yamllint disable-line rule:line-length
     source: https://downloads.mysql.com/archives/get/p/43/file/mysql-shell-8.0.32-linux-glibc2.12-x86-64bit.tar.gz
     organize:
       bin: usr/bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,7 +108,7 @@ parts:
   pin-mysql-apt:
     plugin: nil
     override-pull: |
-      printf "Package: mysql-server\nPin: version 8.0.32*\nPin-Priority: 1001\n" > /etc/apt/preferences.d/mysql
+      printf "Package: mysql-server-8.0\nPin: version 8.0.32*\nPin-Priority: 1001\n" > /etc/apt/preferences.d/mysql
       printf "\nPackage: mysql-router\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
       printf "\nPackage: percona-xtrabackup-80\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
   package-mysql-shell:
@@ -122,7 +122,7 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server
+      - mysql-server-8.0
       - mysql-router
       - percona-xtrabackup-80
       - util-linux


### PR DESCRIPTION
## Issue
We are currently installing `mysql-server`, `mysql-router`, `mysql-shell` and `mysql-cli` from MySQL. However, MySQL updated to 8.0.33 while XtraBackup is still at 8.0.32. This mismatch could cause problems.

## Solution
Install `mysql-server`, `mysql-router` and `mysql-cli` from Ubuntu Security PPA (which is at 8.0.32) -> Ubuntu Security PPA does not have `mysql-shell`
Install only `mysql-shell` from archives of MySQL (which will be at 8.0.32)
Pin versions of `mysql-server`, `mysql-router` and `percona-xtrabackup-80` packages to 8.0.32

```
root@c1:~# charmed-mysql.mysqlsh --version                                                                                                                                             
Cannot set LC_ALL to locale en_US.UTF-8: No such file or directory                                                                                                                     
/snap/charmed-mysql/x1/usr/bin/mysqlsh   Ver 8.0.32 for Linux on x86_64 - for MySQL 8.0.32 (MySQL Community Server (GPL))                                                              
root@c1:~# charmed-mysql.mysql --version                                                                                                                                               
/snap/charmed-mysql/x1/usr/bin/mysql  Ver 8.0.32-0ubuntu0.22.04.2 for Linux on x86_64 ((Ubuntu))                                                                                       
root@c1:~# charmed-mysql.mysqlrouter --version                                                                                                                                         
MySQL Router  Ver 8.0.32-0ubuntu0.22.04.2 for Linux on x86_64 ((Ubuntu))                                                                                                               
root@c1:~# /snap/charmed-mysql/current/usr/sbin/mysqld --version
/snap/charmed-mysql/current/usr/sbin/mysqld  Ver 8.0.32-0ubuntu0.22.04.2 for Linux on x86_64 ((Ubuntu))
root@c1:~# charmed-mysql.xtrabackup --version
/snap/charmed-mysql/x1/usr/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)
```