### PR TITLE
Upload snapcraft logs if publish of snap fails

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,5 +33,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: snapcraft-release-logs
-          path: ~/.local/state/charmcraft/log/
+          path: ~/.local/state/snapcraft/log/
           if-no-files-found: error

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,9 +20,18 @@ jobs:
           name: snap-artifact
       - id: get-snap-name
         run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
-      - uses: snapcore/action-publish@v1
+      - name: Publish snap
+        id: publish
+        uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
           release: ${{ github.ref_name }}
+      - name: Upload snapcraft logs
+        if: ${{ failure() && steps.publish.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapcraft-release-logs
+          path: ~/.local/state/charmcraft/log/
+          if-no-files-found: error


### PR DESCRIPTION
## Issue
We do not publish snapcraft logs when a publish of a snap fails.

## Solution
Publish snapcraft logs when a snap publish fails