### PR TITLE
Move mysqlrouter `/var/run` to `/run`

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -13,7 +13,7 @@ MYSQLD_VAR_RUN=$SNAP_COMMON/var/run/mysqld
 MYSQL_ROUTER_ETC=$SNAP_DATA/etc/mysqlrouter
 MYSQL_ROUTER_VAR_LIB=$SNAP_COMMON/var/lib/mysqlrouter
 MYSQL_ROUTER_VAR_LOG=$SNAP_COMMON/var/log/mysqlrouter
-MYSQL_ROUTER_VAR_RUN=$SNAP_COMMON/var/run/mysqlrouter
+MYSQL_ROUTER_RUN=$SNAP_COMMON/run/mysqlrouter
 
 # Creating all the needed directories
 mkdir -p $MYSQL_ETC
@@ -24,7 +24,7 @@ mkdir -p $MYSQLD_VAR_RUN
 mkdir -p $MYSQL_ROUTER_ETC
 mkdir -p $MYSQL_ROUTER_VAR_LIB
 mkdir -p $MYSQL_ROUTER_VAR_LOG
-mkdir -p $MYSQL_ROUTER_VAR_RUN
+mkdir -p $MYSQL_ROUTER_RUN
 
 # Copy over mysql config file
 cp -r $SNAP/etc/mysql $SNAP_DATA/etc/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,8 @@ package-repositories:
     key-id: 630239CC130E1A7FD81A27B140976EAF437D05B5
     url: http://security.ubuntu.com/ubuntu/
   - type: apt
+    ppa: data-platform/mysql-shell
+  - type: apt
     components:
       - main
     suites:
@@ -116,19 +118,12 @@ parts:
       printf "Package: mysql-server-8.0\nPin: version 8.0.32*\nPin-Priority: 1001\n" > /etc/apt/preferences.d/mysql
       printf "\nPackage: mysql-router\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
       printf "\nPackage: percona-xtrabackup-80\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
-  package-mysql-shell:
-    plugin: dump
-    source: https://downloads.mysql.com/archives/get/p/43/file/mysql-shell-8.0.32-linux-glibc2.12-x86-64bit.tar.gz
-    organize:
-      bin: usr/bin
-      libexec: usr/libexec
-      lib: usr/lib
-      share: usr/share
   packages-deb:
     plugin: nil
     stage-packages:
       - mysql-server-8.0
       - mysql-router
+      - mysql-shell
       - percona-xtrabackup-80
       - util-linux
     after:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,7 +66,7 @@ slots:
     interface: content
     content: socket-directory
     write:
-      - $SNAP_COMMON/var/run/mysqlrouter
+      - $SNAP_COMMON/run/mysqlrouter
 
 apps:
   mysql:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ package-repositories:
       - main
     suites:
       - jammy
-    key-id: 630239CC130E1A7FD81A27B140976EAF437D05B5
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
     url: http://security.ubuntu.com/ubuntu/
   - type: apt
     ppa: data-platform/mysql-shell

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
-version: '8.0.32-0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '8.0.33-0' # just for humans, typically '1.2+git' or '1.3.2'
 summary: MySQL server in a snap. # 79 char long summary
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,


### PR DESCRIPTION
FHS 3.0 (released in 2015) moved `/var/run` to `/run`
https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard

- Update mysql packages from 8.0.32 to 8.0.33
- Install mysqlsh from PPA