### PR TITLE
Move `/var/lib/mysqlrouter` from SNAP_COMMON to SNAP_DATA

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ layout:
   /etc/mysqlrouter:
     bind: $SNAP_DATA/etc/mysqlrouter
   /var/lib/mysqlrouter:
-    bind: $SNAP_COMMON/var/lib/mysqlrouter
+    bind: $SNAP_DATA/var/lib/mysqlrouter
   /var/log/mysqlrouter:
     bind: $SNAP_COMMON/var/log/mysqlrouter
   /usr/lib/mysqlsh:


### PR DESCRIPTION
`/var/lib/mysqlrouter` contains state.json, which could have a different version between snap revisions

Further context: https://chat.canonical.com/canonical/pl/pxn5wh7ysfdpunad3p998rzxyr