### PR TITLE
Use symlinks instead of bind mounts for mysqlrouter directories

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,11 +40,11 @@ layout:
   /usr/lib/mysql-router:
     symlink: $SNAP/usr/lib/mysql-router
   /etc/mysqlrouter:
-    bind: $SNAP_DATA/etc/mysqlrouter
+    symlink: $SNAP_DATA/etc/mysqlrouter
   /var/lib/mysqlrouter:
-    bind: $SNAP_DATA/var/lib/mysqlrouter
+    symlink: $SNAP_DATA/var/lib/mysqlrouter
   /var/log/mysqlrouter:
-    bind: $SNAP_COMMON/var/log/mysqlrouter
+    symlink: $SNAP_COMMON/var/log/mysqlrouter
   /var/log/mysqlsh:
     bind: $SNAP_COMMON/var/log/mysqlsh
   /usr/lib/mysqlsh:


### PR DESCRIPTION
## Issue
Directories that use bind mounts cannot be deleted & re-created (they will not be remounted)
The mysql-router vm charm deletes directories to clean up configuration & state when the mysql<->mysqlrouter relation is broken

## Solution
Use symlinks instead of bind mounts

## Context
https://forum.snapcraft.io/t/snap-layouts/7207/33