### PR TITLE
DPE-2223 DPE-1685 All packages installed from trusted canonical sources

### DIFF
--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -12,7 +12,7 @@ EXPORTER_OPTS="--no-collect.binlog_size \
 --no-collect.perf_schema.tableiowaits \
 --no-collect.perf_schema.tablelocks \
 --no-collect.auto_increment.columns"
-EXPORTER_PATH="/usr/bin/mysqld_exporter"
+EXPORTER_PATH="/usr/bin/prometheus-mysqld-exporter"
 SOCKET="/var/run/mysqld/mysqld.sock"
 
 if [ -z "$SNAP" ]; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -114,23 +114,16 @@ apps:
       - network
       - network-bind
 parts:
-  pin-mysql-apt:
-    plugin: nil
-    override-pull: |
-      printf "Package: mysql-server-8.0\nPin: version 8.0.33*\nPin-Priority: 1001\n" > /etc/apt/preferences.d/mysql
-      printf "\nPackage: mysql-router\nPin: version 8.0.33*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0
-      - mysql-router
-      - mysql-shell
-      - prometheus-mysqld-exporter
-      - prometheus-mysqlrouter-exporter
-      - xtrabackup
+      - mysql-server-8.0=8.0.33-0ubuntu0.22.04.4
+      - mysql-router=8.0.33-0ubuntu0.22.04.4
+      - mysql-shell=8.0.33-0ubuntu0.22.04.1~ppa3
+      - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa1
+      - prometheus-mysqlrouter-exporter=4.0.5-0ubuntu0.22.04.1~ppa1
+      - xtrabackup=8.0.33-27-0ubuntu0.22.04.1~ppa1
       - util-linux
-    after:
-      - pin-mysql-apt
   wrapper:
     plugin: dump
     source: snap/local

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,12 +25,11 @@ package-repositories:
   - type: apt
     ppa: data-platform/mysql-shell
   - type: apt
-    components:
-      - main
-    suites:
-      - jammy
-    key-id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
-    url: http://repo.percona.com/percona/apt
+    ppa: data-platform/xtrabackup
+  - type: apt
+    ppa: data-platform/mysqld-exporter
+  - type: apt
+    ppa: data-platform/mysqlrouter-exporter
 
 layout:
   /var/lib/mysql-files:
@@ -110,6 +109,7 @@ apps:
   mysqld-exporter:
     command: start-mysqld-exporter.sh
     daemon: simple
+    install-mode: disable
     plugs:
       - network
       - network-bind
@@ -117,29 +117,20 @@ parts:
   pin-mysql-apt:
     plugin: nil
     override-pull: |
-      printf "Package: mysql-server-8.0\nPin: version 8.0.32*\nPin-Priority: 1001\n" > /etc/apt/preferences.d/mysql
-      printf "\nPackage: mysql-router\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
-      printf "\nPackage: percona-xtrabackup-80\nPin: version 8.0.32*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
+      printf "Package: mysql-server-8.0\nPin: version 8.0.33*\nPin-Priority: 1001\n" > /etc/apt/preferences.d/mysql
+      printf "\nPackage: mysql-router\nPin: version 8.0.33*\nPin-Priority: 1001\n" >> /etc/apt/preferences.d/mysql
   packages-deb:
     plugin: nil
     stage-packages:
       - mysql-server-8.0
       - mysql-router
       - mysql-shell
-      - percona-xtrabackup-80
+      - prometheus-mysqld-exporter
+      - prometheus-mysqlrouter-exporter
+      - xtrabackup
       - util-linux
     after:
       - pin-mysql-apt
   wrapper:
     plugin: dump
     source: snap/local
-  mysqld-exporter:
-    plugin: dump
-    source: https://github.com/prometheus/mysqld_exporter/releases/download/v0.14.0/mysqld_exporter-0.14.0.linux-amd64.tar.gz
-    source-type: tar
-    source-checksum: sha256/c17402137a4e9745f593127f162c1003298910cb8aa7d05bee3384738de094ae
-    organize:
-      'mysqld_exporter': usr/bin/mysqld_exporter
-    prime:
-      - -LICENSE
-      - -NOTICE


### PR DESCRIPTION
## Issues
- We now have PPAs for xtrabackup, mysql-exporter and mysqlrouter-exporter. However, we are still installing them from upstream.
- We are pinning v8.0.32 of mysql, but we install v8.0.33 from the security.ubuntu.com repo
- We are enabling mysqld-exporter by default when the snap starts, which should not happen as the snap will also be used in the mysqlrouter charm

## Solutions
- Use the PPAs to install xtrabackup, mysql-exporter and mysqlrouter-exporter instead of upstream sources
- Pin v8.0.33
- Disable mysqld-exporter upon startup