### PR TITLE
DPE-2423 Upgrade mysql and related tools from 8.0.33 to 8.0.34

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
-version: '8.0.33' # just for humans, typically '1.2+git' or '1.3.2'
+version: '8.0.34' # just for humans, typically '1.2+git' or '1.3.2'
 summary: MySQL server in a snap. # 79 char long summary
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -118,12 +118,12 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.33-0ubuntu0.22.04.4
-      - mysql-router=8.0.33-0ubuntu0.22.04.4
-      - mysql-shell=8.0.33-0ubuntu0.22.04.1~ppa3
+      - mysql-server-8.0=8.0.34-0ubuntu0.22.04.1
+      - mysql-router=8.0.34-0ubuntu0.22.04.1
+      - mysql-shell=8.0.34-0ubuntu0.22.04.1~ppa1
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa1
       - prometheus-mysqlrouter-exporter=4.0.5-0ubuntu0.22.04.1~ppa1
-      - xtrabackup=8.0.33-27-0ubuntu0.22.04.1~ppa1
+      - xtrabackup=8.0.34-29-0ubuntu0.22.04.1~ppa1
       - util-linux
     organize:
       usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0


### PR DESCRIPTION
## Issue
MySQL has released v8.0.34. Additionally, our PPAs (for mysql-shell, xtrabackup) have been upgraded for 8.0.34

## Solution
Upgrade from 8.0.33 to 8.0.34