### PR TITLE
DPE-2618 - Fix shell default log path

### DIFF
--- a/snap/local/run-mysql-router-password.sh
+++ b/snap/local/run-mysql-router-password.sh
@@ -2,5 +2,10 @@
 
 # For security measures, applications should not be run as sudo.
 # Execute mysqlrouter as the non-sudo user: snap-daemon.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/mysqlrouter_passwd "$@"
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon \
+    -- \
+    "${SNAP}/usr/bin/mysqlrouter_passwd" \
+    "$@"

--- a/snap/local/run-mysql-router.sh
+++ b/snap/local/run-mysql-router.sh
@@ -2,5 +2,10 @@
 
 # For security measures, applications should not be run as sudo.
 # Execute mysqlrouter as the non-sudo user: snap-daemon.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/mysqlrouter "$@"
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon \
+    -- \
+    "${SNAP}/usr/bin/mysqlrouter" \
+    "$@"

--- a/snap/local/run-mysqlsh.sh
+++ b/snap/local/run-mysqlsh.sh
@@ -3,4 +3,5 @@
 # For security measures, applications should not be run as sudo.
 # Execute mysqlsh as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- env MYSQLSH_USER_CONFIG_HOME=/tmp/mysqlsh $SNAP/usr/bin/mysqlsh --log-file /var/log/mysqlsh/mysqlsh.log "$@"
+  --regid snap_daemon -- env MYSQLSH_USER_CONFIG_HOME=/tmp/mysqlsh $SNAP/usr/bin/mysqlsh \
+  --log-file $SNAP_COMMON/var/log/mysqlsh/mysqlsh.log "$@"

--- a/snap/local/run-mysqlsh.sh
+++ b/snap/local/run-mysqlsh.sh
@@ -2,6 +2,12 @@
 
 # For security measures, applications should not be run as sudo.
 # Execute mysqlsh as the non-sudo user: snap-daemon.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- env MYSQLSH_USER_CONFIG_HOME=/tmp/snap-private-tmp/snap.$SNAP_NAME/tmp \
-  $SNAP/usr/bin/mysqlsh --log-file $SNAP_COMMON/var/log/mysqlsh/mysqlsh.log "$@"
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon \
+    -- \
+    env MYSQLSH_USER_CONFIG_HOME="/tmp/snap-private-tmp/snap.${SNAP_NAME}/tmp" \
+    "${SNAP}/usr/bin/mysqlsh" \
+    --log-file "${SNAP_COMMON}/var/log/mysqlsh/mysqlsh.log" \
+    "$@"

--- a/snap/local/run-mysqlsh.sh
+++ b/snap/local/run-mysqlsh.sh
@@ -3,5 +3,5 @@
 # For security measures, applications should not be run as sudo.
 # Execute mysqlsh as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- env MYSQLSH_USER_CONFIG_HOME=/tmp/mysqlsh $SNAP/usr/bin/mysqlsh \
-  --log-file $SNAP_COMMON/var/log/mysqlsh/mysqlsh.log "$@"
+  --regid snap_daemon -- env MYSQLSH_USER_CONFIG_HOME=/tmp/snap-private-tmp/snap.$SNAP_NAME/tmp \
+  $SNAP/usr/bin/mysqlsh --log-file $SNAP_COMMON/var/log/mysqlsh/mysqlsh.log "$@"

--- a/snap/local/run-mysqlsh.sh
+++ b/snap/local/run-mysqlsh.sh
@@ -7,7 +7,7 @@ exec "${SNAP}/usr/bin/setpriv" \
     --reuid snap_daemon \
     --regid snap_daemon \
     -- \
-    env MYSQLSH_USER_CONFIG_HOME="/tmp/snap-private-tmp/snap.${SNAP_NAME}/tmp" \
+    env MYSQLSH_USER_CONFIG_HOME="/tmp/snap-private-tmp/snap.${SNAP_NAME}/tmp/mysqlsh" \
     "${SNAP}/usr/bin/mysqlsh" \
     --log-file "${SNAP_COMMON}/var/log/mysqlsh/mysqlsh.log" \
     "$@"

--- a/snap/local/start-mysql-router-exporter.sh
+++ b/snap/local/start-mysql-router-exporter.sh
@@ -3,12 +3,12 @@
 set -eo pipefail # Exit on error
 
 EXPORTER_OPTS="--collect.metadata.status \
---collect.route.connections.byte_from_server \
---collect.route.connections.byte_to_server \
---collect.route.connections.time_started \
---collect.route.connections.time_connected_to_server \
---collect.route.connections.time_last_sent_to_server \
---collect.route.connections.time_received_from_server"
+    --collect.route.connections.byte_from_server \
+    --collect.route.connections.byte_to_server \
+    --collect.route.connections.time_started \
+    --collect.route.connections.time_connected_to_server \
+    --collect.route.connections.time_last_sent_to_server \
+    --collect.route.connections.time_received_from_server"
 EXPORTER_PATH="/usr/bin/mysqlrouter_exporter"
 
 if [ -n "$SNAP" ]; then
@@ -37,7 +37,7 @@ if [ -n "$SNAP" ]; then
         env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
         MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
         MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
-        "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS") $(echo "$TLS_OPTS")
+        "$EXPORTER_PATH" "$EXPORTER_OPTS" "$TLS_OPTS"
 else
     if [ -z "$MYSQLROUTER_EXPORTER_URL" ]; then
         echo "MYSQLROUTER_EXPORTER_URL must be set"
@@ -60,5 +60,5 @@ else
         TLS_OPTS="--skip-tls-verify"
     fi
 
-    "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS") $(echo "$TLS_OPTS")
+    "$EXPORTER_PATH" "$EXPORTER_OPTS" "$TLS_OPTS"
 fi

--- a/snap/local/start-mysql-router-exporter.sh
+++ b/snap/local/start-mysql-router-exporter.sh
@@ -37,7 +37,7 @@ if [ -n "$SNAP" ]; then
         env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
         MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
         MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
-        "$EXPORTER_PATH" "$EXPORTER_OPTS" "$TLS_OPTS"
+        "/snap/charmed-mysql/current$EXPORTER_PATH" $(echo "$EXPORTER_OPTS") "$TLS_OPTS"
 else
     if [ -z "$MYSQLROUTER_EXPORTER_URL" ]; then
         echo "MYSQLROUTER_EXPORTER_URL must be set"
@@ -60,5 +60,5 @@ else
         TLS_OPTS="--skip-tls-verify"
     fi
 
-    "$EXPORTER_PATH" "$EXPORTER_OPTS" "$TLS_OPTS"
+    "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS") "$TLS_OPTS"
 fi

--- a/snap/local/start-mysql-router-exporter.sh
+++ b/snap/local/start-mysql-router-exporter.sh
@@ -2,13 +2,15 @@
 
 set -eo pipefail # Exit on error
 
-EXPORTER_OPTS="--collect.metadata.status \
-    --collect.route.connections.byte_from_server \
-    --collect.route.connections.byte_to_server \
-    --collect.route.connections.time_started \
-    --collect.route.connections.time_connected_to_server \
-    --collect.route.connections.time_last_sent_to_server \
-    --collect.route.connections.time_received_from_server"
+EXPORTER_OPTS=(
+    "--collect.metadata.status"
+    "--collect.route.connections.byte_from_server"
+    "--collect.route.connections.byte_to_server"
+    "--collect.route.connections.time_started"
+    "--collect.route.connections.time_connected_to_server"
+    "--collect.route.connections.time_last_sent_to_server"
+    "--collect.route.connections.time_received_from_server"
+)
 EXPORTER_PATH="/usr/bin/mysqlrouter_exporter"
 
 if [ -n "$SNAP" ]; then
@@ -37,7 +39,7 @@ if [ -n "$SNAP" ]; then
         env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
         MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
         MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
-        "/snap/charmed-mysql/current$EXPORTER_PATH" $(echo "$EXPORTER_OPTS") "$TLS_OPTS"
+        "/snap/charmed-mysql/current$EXPORTER_PATH" "${EXPORTER_OPTS[@]}" "$TLS_OPTS"
 else
     if [ -z "$MYSQLROUTER_EXPORTER_URL" ]; then
         echo "MYSQLROUTER_EXPORTER_URL must be set"
@@ -60,5 +62,5 @@ else
         TLS_OPTS="--skip-tls-verify"
     fi
 
-    "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS") "$TLS_OPTS"
+    "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}" "$TLS_OPTS"
 fi

--- a/snap/local/start-mysql-router.sh
+++ b/snap/local/start-mysql-router.sh
@@ -11,4 +11,4 @@ exec "${SNAP}/usr/bin/setpriv" \
     -- \
     "${SNAP}/usr/bin/mysqlrouter" \
     --config "${SNAP_DATA}/etc/mysqlrouter/mysqlrouter.conf" \
-    "${EXTRA_OPTIONS}"
+    $(echo "${EXTRA_OPTIONS}")

--- a/snap/local/start-mysql-router.sh
+++ b/snap/local/start-mysql-router.sh
@@ -4,8 +4,11 @@
 # Execute mysqlrouter as the non-sudo user: snap-daemon.
 EXTRA_OPTIONS="$(snapctl get mysqlrouter.extra-options)"
 
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon \
-  -- $SNAP/usr/bin/mysqlrouter \
-  --config $SNAP_DATA/etc/mysqlrouter/mysqlrouter.conf \
-  $(echo "$EXTRA_OPTIONS")
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon \
+    -- \
+    "${SNAP}/usr/bin/mysqlrouter" \
+    --config "${SNAP_DATA}/etc/mysqlrouter/mysqlrouter.conf" \
+    "${EXTRA_OPTIONS}"

--- a/snap/local/start-mysql-router.sh
+++ b/snap/local/start-mysql-router.sh
@@ -2,7 +2,9 @@
 
 # For security measures, daemons should not be run as sudo.
 # Execute mysqlrouter as the non-sudo user: snap-daemon.
-EXTRA_OPTIONS="$(snapctl get mysqlrouter.extra-options)"
+
+# Retrieve extra options as array
+mapfile -t EXTRA_OPTIONS < <(snapctl get mysqlrouter.extra-options)
 
 exec "${SNAP}/usr/bin/setpriv" \
     --clear-groups \
@@ -11,4 +13,4 @@ exec "${SNAP}/usr/bin/setpriv" \
     -- \
     "${SNAP}/usr/bin/mysqlrouter" \
     --config "${SNAP_DATA}/etc/mysqlrouter/mysqlrouter.conf" \
-    $(echo "${EXTRA_OPTIONS}")
+    "${EXTRA_OPTIONS[@]}"

--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -21,7 +21,7 @@ if [ -z "$SNAP" ]; then
         echo "DATA_SOURCE_NAME must be set"
         exit 1
     fi
-    exec "$EXPORTER_PATH" "$EXPORTER_OPTS"
+    exec "/snap/charmed-mysql/current$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
 else
     # When running as a snap, expect `exporter.user` and `exporter.password`
     EXPORTER_USER="$(snapctl get exporter.user)"
@@ -42,5 +42,5 @@ else
         --regid snap_daemon \
         -- \
         env DATA_SOURCE_NAME="${EXPORTER_USER}:${EXPORTER_PASS}@unix(${SOCKET})/" \
-        "$EXPORTER_PATH" "$EXPORTER_OPTS"
+        "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
 fi

--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -2,16 +2,18 @@
 
 set -eo pipefail # Exit on error
 
-EXPORTER_OPTS="--no-collect.binlog_size \
-    --no-collect.info_schema.processlist \
-    --no-collect.info_schema.tables \
-    --no-collect.info_schema.tablestats \
-    --no-collect.info_schema.userstats \
-    --no-collect.info_schema.query_response_time \
-    --no-collect.perf_schema.indexiowaits \
-    --no-collect.perf_schema.tableiowaits \
-    --no-collect.perf_schema.tablelocks \
-    --no-collect.auto_increment.columns"
+EXPORTER_OPTS=(
+    "--no-collect.binlog_size"
+    "--no-collect.info_schema.processlist"
+    "--no-collect.info_schema.tables"
+    "--no-collect.info_schema.tablestats"
+    "--no-collect.info_schema.userstats"
+    "--no-collect.info_schema.query_response_time"
+    "--no-collect.perf_schema.indexiowaits"
+    "--no-collect.perf_schema.tableiowaits"
+    "--no-collect.perf_schema.tablelocks"
+    "--no-collect.auto_increment.columns"
+)
 EXPORTER_PATH="/usr/bin/prometheus-mysqld-exporter"
 SOCKET="/var/run/mysqld/mysqld.sock"
 
@@ -21,7 +23,7 @@ if [ -z "$SNAP" ]; then
         echo "DATA_SOURCE_NAME must be set"
         exit 1
     fi
-    exec "/snap/charmed-mysql/current$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+    exec "/snap/charmed-mysql/current$EXPORTER_PATH" "${EXPORTER_OPTS[@]}"
 else
     # When running as a snap, expect `exporter.user` and `exporter.password`
     EXPORTER_USER="$(snapctl get exporter.user)"
@@ -42,5 +44,5 @@ else
         --regid snap_daemon \
         -- \
         env DATA_SOURCE_NAME="${EXPORTER_USER}:${EXPORTER_PASS}@unix(${SOCKET})/" \
-        "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+        "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}"
 fi

--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -3,15 +3,15 @@
 set -eo pipefail # Exit on error
 
 EXPORTER_OPTS="--no-collect.binlog_size \
---no-collect.info_schema.processlist \
---no-collect.info_schema.tables \
---no-collect.info_schema.tablestats \
---no-collect.info_schema.userstats \
---no-collect.info_schema.query_response_time \
---no-collect.perf_schema.indexiowaits \
---no-collect.perf_schema.tableiowaits \
---no-collect.perf_schema.tablelocks \
---no-collect.auto_increment.columns"
+    --no-collect.info_schema.processlist \
+    --no-collect.info_schema.tables \
+    --no-collect.info_schema.tablestats \
+    --no-collect.info_schema.userstats \
+    --no-collect.info_schema.query_response_time \
+    --no-collect.perf_schema.indexiowaits \
+    --no-collect.perf_schema.tableiowaits \
+    --no-collect.perf_schema.tablelocks \
+    --no-collect.auto_increment.columns"
 EXPORTER_PATH="/usr/bin/prometheus-mysqld-exporter"
 SOCKET="/var/run/mysqld/mysqld.sock"
 
@@ -21,7 +21,7 @@ if [ -z "$SNAP" ]; then
         echo "DATA_SOURCE_NAME must be set"
         exit 1
     fi
-    exec "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+    exec "$EXPORTER_PATH" "$EXPORTER_OPTS"
 else
     # When running as a snap, expect `exporter.user` and `exporter.password`
     EXPORTER_USER="$(snapctl get exporter.user)"
@@ -39,7 +39,8 @@ else
     exec "$SNAP"/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
-        --regid snap_daemon -- \
+        --regid snap_daemon \
+        -- \
         env DATA_SOURCE_NAME="${EXPORTER_USER}:${EXPORTER_PASS}@unix(${SOCKET})/" \
-        "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+        "$EXPORTER_PATH" "$EXPORTER_OPTS"
 fi

--- a/snap/local/start-mysqld.sh
+++ b/snap/local/start-mysqld.sh
@@ -3,5 +3,10 @@
 # For security measures, applications should not be run as sudo.
 # Execute mysqld_safe as the non-sudo user: snap-daemon
 # Note: group is set to root due to backups related intricacies.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid root -- $SNAP/usr/bin/mysqld_safe --defaults-file=$SNAP_DATA/etc/mysql/mysql.cnf
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid root \
+    -- \
+    "${SNAP}/usr/bin/mysqld_safe" \
+    --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -40,11 +40,20 @@ def test_all_services():
     with open("snap/snapcraft.yaml") as file:
         snapcraft = yaml.safe_load(file)
 
-        skip = ["mysqlrouter-service", "mysqld-exporter", "mysqlrouter-exporter"]
+        skip = ["mysqlrouter-service", "mysqlrouter-exporter"]
 
         for app, data in snapcraft["apps"].items():
             if bool(data.get("daemon")) and app not in skip:
                 print(f"\nTesting {snapcraft['name']}.{app} service....")
+
+                if app == "mysqld-exporter":
+                    # set a dummy credentials so service can start
+                    for config in ["exporter.user", "exporter.password"]:
+                        subprocess.run(
+                            f"sudo snap set {snapcraft['name']} {config}=dummy".split(),
+                            check=True,
+                        )
+
                 subprocess.run(
                     f"sudo snap start {snapcraft['name']}.{app}".split(), check=True
                 )


### PR DESCRIPTION
Fix mysql-shell default log file path for the snap common data.

Tested on https://github.com/canonical/mysql-operator/pull/381 
using branch `8.0/edge/shell-log-dir` (rev94)

**Chore**
* reformatted scripts for readability