### PR TITLE
[DPE-3824, DPE-3689] router exporter TLS + update mysqld exporter to v0.15

### DIFF
--- a/snap/local/start-mysql-router-exporter.sh
+++ b/snap/local/start-mysql-router-exporter.sh
@@ -14,71 +14,90 @@ EXPORTER_OPTS=(
 EXPORTER_PATH="/usr/bin/mysqlrouter_exporter"
 
 if [ -n "$SNAP" ]; then
-    EXPORTER_PATH="${SNAP}${EXPORTER_PATH}"
     MYSQLROUTER_EXPORTER_USER="$(snapctl get mysqlrouter-exporter.user)"
     MYSQLROUTER_EXPORTER_PASS="$(snapctl get mysqlrouter-exporter.password)"
     MYSQLROUTER_EXPORTER_URL="$(snapctl get mysqlrouter-exporter.url)"
+    MYSQLROUTER_EXPORTER_SERVICE_NAME="$(snapctl get mysqlrouter-exporter.service-name)"
     MYSQLROUTER_TLS_CACERT_PATH="$(snapctl get mysqlrouter.tls-cacert-path)"
     MYSQLROUTER_TLS_CERT_PATH="$(snapctl get mysqlrouter.tls-cert-path)"
     MYSQLROUTER_TLS_KEY_PATH="$(snapctl get mysqlrouter.tls-key-path)"
+fi
 
-    if [ -z "$MYSQLROUTER_EXPORTER_URL" ]; then
-        echo "mysqlrouter-exporter.url must be set"
-        exit 1
-    fi
-
-    if [[ -z "$MYSQLROUTER_EXPORTER_USER" || -z "$MYSQLROUTER_EXPORTER_PASS" ]]; then
-        echo "mysqlrouter-exporter.user and mysqlrouter-exporter.password must be set"
-        exit 1
-    fi
-
-    if [[ -n "$MYSQLROUTER_TLS_CACERT_PATH" && -n "$MYSQLROUTER_TLS_CERT_PATH" && -n "$MYSQLROUTER_TLS_KEY_PATH" ]]; then
-        # For security measures, daemons should not be run as sudo.
-        # Execute mysqlrouter-exporter as the non-sudo user: snap-daemon.
-        exec "$SNAP"/usr/bin/setpriv \
-            --clear-groups \
-            --reuid snap_daemon \
-            --regid snap_daemon -- \
-            env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
-            MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
-            MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
-            MYSQLROUTER_TLS_CACERT_PATH="${MYSQLROUTER_TLS_CACERT_PATH}" \
-            MYSQLROUTER_TLS_CERT_PATH="${MYSQLROUTER_TLS_CERT_PATH}" \
-            MYSQLROUTER_TLS_KEY_PATH="${MYSQLROUTER_TLS_KEY_PATH}" \
-            "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}"
+# Validate certain required input args
+if [ -z "${MYSQLROUTER_EXPORTER_URL}" ]; then
+    if [ -n "${SNAP}" ]; then
+        echo "Error: mysqlrouter-exporter.url must be set" >&2
     else
-        # For security measures, daemons should not be run as sudo.
-        # Execute mysqlrouter-exporter as the non-sudo user: snap-daemon.
-        exec "$SNAP"/usr/bin/setpriv \
-            --clear-groups \
-            --reuid snap_daemon \
-            --regid snap_daemon -- \
-            env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
-            MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
-            MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
-            "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}" --skip-tls-verify
+        echo "Error: MYSQLROUTER_EXPORTER_URL must be set" >&2
     fi
+    exit 1
+fi
+
+if [ -z "${MYSQLROUTER_EXPORTER_USER}" ]; then
+    if [ -n "${SNAP}" ]; then
+        echo "Error: mysqlrouter-exporter.user must be set" >&2
+    else
+        echo "Error: MYSQLROUTER_EXPORTER_USER must be set" >&2
+    fi
+    exit 1
+fi
+
+if [ -z "${MYSQLROUTER_EXPORTER_PASS}" ]; then
+    if [ -n "${SNAP}" ]; then
+        echo "Error: mysqlrouter-exporter.password must be set" >&2
+    else
+        echo "Error: MYSQLROUTER_EXPORTER_PASS must be set" >&2
+    fi
+    exit 1
+fi
+
+if [ -z "${MYSQLROUTER_EXPORTER_SERVICE_NAME}" ]; then
+    if [ -n "${SNAP}" ]; then
+        echo "Error: mysqlrouter-exporter.service-name must be set" >&2
+    else
+        echo "Error: MYSQLROUTER_EXPORTER_SERVICE_NAME must be set" >&2
+    fi
+    exit 1
+fi
+
+# Execute the mysqlrouter_exporter command 
+if [ -n "${SNAP}" ]; then
+    SETPRIV_OPTIONS=(
+        "--clear-groups"
+        "--reuid"
+        "snap_daemon"
+        "--regid"
+        "snap_daemon"
+    )
+
+    EXPORTER_ENV=(
+        "MYSQLROUTER_EXPORTER_URL=${MYSQLROUTER_EXPORTER_URL}"
+        "MYSQLROUTER_EXPORTER_USER=${MYSQLROUTER_EXPORTER_USER}"
+        "MYSQLROUTER_EXPORTER_PASS=${MYSQLROUTER_EXPORTER_PASS}"
+    )
+
+    EXPORTER_OPTS+=("--service-name=${MYSQLROUTER_SERVICE_NAME}")
+
+    if [[
+        -n "${MYSQLROUTER_TLS_CACERT_PATH}" && \
+        -n "${MYSQLROUTER_TLS_CERT_PATH}" && \
+        -n "${MYSQLROUTER_TLS_KEY_PATH}"
+    ]]; then
+        EXPORTER_ENV+=("MYSQLROUTER_TLS_CACERT_PATH=${MYSQLROUTER_TLS_CACERT_PATH}")
+        EXPORTER_ENV+=("MYSQLROUTER_TLS_CERT_PATH=${MYSQLROUTER_TLS_CERT_PATH}")
+        EXPORTER_ENV+=("MYSQLROUTER_TLS_KEY_PATH=${MYSQLROUTER_TLS_KEY_PATH}")
+    else
+        EXPORTER_OPTS+=("--skip-tls-verify")
+    fi
+
+    # For security measures, daemons should not be run as sudo.
+    # Execute mysqlrouter-exporter as the non-sudo user: snap-daemon.
+    exec "${SNAP}"/usr/bin/setpriv "${SETPRIV_OPTIONS[@]}" -- \
+        env "${EXPORTER_ENV[@]}" "${SNAP}${EXPORTER_PATH}" "${EXPORTER_OPTS[@]}"
 else
-    if [ -z "$MYSQLROUTER_EXPORTER_URL" ]; then
-        echo "MYSQLROUTER_EXPORTER_URL must be set"
-        exit 1
+    if [[ -z "$MYSQLROUTER_TLS_CACERT_PATH" || -z "$MYSQLROUTER_TLS_CERT_PATH" || -z "$MYSQLROUTER_TLS_KEY_PATH" ]]; then
+        EXPORTER_OPTS+=("--skip-tls-verify")
     fi
 
-    if [ -z "$MYSQLROUTER_EXPORTER_USER" ]; then
-        echo "MYSQLROUTER_EXPORTER_USER must be set"
-        exit 1
-    fi
-
-    if [ -z "$MYSQLROUTER_EXPORTER_PASS" ]; then
-        echo "MYSQLROUTER_EXPORTER_PASS must be set"
-        exit 1
-    fi
-
-    if [[ -n "$MYSQLROUTER_TLS_CACERT_PATH" && -n "$MYSQLROUTER_TLS_CERT_PATH" && -n "$MYSQLROUTER_TLS_KEY_PATH" ]]; then
-        TLS_OPTS=""
-    else
-        TLS_OPTS="--skip-tls-verify"
-    fi
-
-    "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}" "$TLS_OPTS"
+    "${EXPORTER_PATH}" "${EXPORTER_OPTS[@]}"
 fi

--- a/snap/local/start-mysql-router-exporter.sh
+++ b/snap/local/start-mysql-router-exporter.sh
@@ -18,7 +18,9 @@ if [ -n "$SNAP" ]; then
     MYSQLROUTER_EXPORTER_USER="$(snapctl get mysqlrouter-exporter.user)"
     MYSQLROUTER_EXPORTER_PASS="$(snapctl get mysqlrouter-exporter.password)"
     MYSQLROUTER_EXPORTER_URL="$(snapctl get mysqlrouter-exporter.url)"
-    TLS_OPTS="--skip-tls-verify"
+    MYSQLROUTER_TLS_CACERT_PATH="$(snapctl get mysqlrouter.tls-cacert-path)"
+    MYSQLROUTER_TLS_CERT_PATH="$(snapctl get mysqlrouter.tls-cert-path)"
+    MYSQLROUTER_TLS_KEY_PATH="$(snapctl get mysqlrouter.tls-key-path)"
 
     if [ -z "$MYSQLROUTER_EXPORTER_URL" ]; then
         echo "mysqlrouter-exporter.url must be set"
@@ -30,16 +32,32 @@ if [ -n "$SNAP" ]; then
         exit 1
     fi
 
-    # For security measures, daemons should not be run as sudo.
-    # Execute mysqlrouter-exporter as the non-sudo user: snap-daemon.
-    exec "$SNAP"/usr/bin/setpriv \
-        --clear-groups \
-        --reuid snap_daemon \
-        --regid snap_daemon -- \
-        env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
-        MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
-        MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
-        "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}" "$TLS_OPTS"
+    if [[ -n "$MYSQLROUTER_TLS_CACERT_PATH" && -n "$MYSQLROUTER_TLS_CERT_PATH" && -n "$MYSQLROUTER_TLS_KEY_PATH" ]]; then
+        # For security measures, daemons should not be run as sudo.
+        # Execute mysqlrouter-exporter as the non-sudo user: snap-daemon.
+        exec "$SNAP"/usr/bin/setpriv \
+            --clear-groups \
+            --reuid snap_daemon \
+            --regid snap_daemon -- \
+            env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
+            MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
+            MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
+            MYSQLROUTER_TLS_CACERT_PATH="${MYSQLROUTER_TLS_CACERT_PATH}" \
+            MYSQLROUTER_TLS_CERT_PATH="${MYSQLROUTER_TLS_CERT_PATH}" \
+            MYSQLROUTER_TLS_KEY_PATH="${MYSQLROUTER_TLS_KEY_PATH}" \
+            "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}"
+    else
+        # For security measures, daemons should not be run as sudo.
+        # Execute mysqlrouter-exporter as the non-sudo user: snap-daemon.
+        exec "$SNAP"/usr/bin/setpriv \
+            --clear-groups \
+            --reuid snap_daemon \
+            --regid snap_daemon -- \
+            env MYSQLROUTER_EXPORTER_URL="${MYSQLROUTER_EXPORTER_URL}" \
+            MYSQLROUTER_EXPORTER_USER="${MYSQLROUTER_EXPORTER_USER}" \
+            MYSQLROUTER_EXPORTER_PASS="${MYSQLROUTER_EXPORTER_PASS}" \
+            "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}" --skip-tls-verify
+    fi
 else
     if [ -z "$MYSQLROUTER_EXPORTER_URL" ]; then
         echo "MYSQLROUTER_EXPORTER_URL must be set"

--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -18,12 +18,13 @@ EXPORTER_PATH="/usr/bin/prometheus-mysqld-exporter"
 SOCKET="/var/run/mysqld/mysqld.sock"
 
 if [ -z "$SNAP" ]; then
-    # When not running as a snap, expect `DATA_SOURCE_NAME` to be set.
-    if [ -z "$DATA_SOURCE_NAME" ]; then
-        echo "DATA_SOURCE_NAME must be set"
+    # When not running as a snap, expect `EXPORTER_USER` and `EXPORTER_PASS` to be set.
+    if [ -z "$EXPORTER_USER" || -z "$EXPORTER_PASS" ]; then
+        echo "EXPORTER_USER and EXPORTER_PASS must be set"
         exit 1
     fi
-    exec "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}"
+    exec env MYSQLD_EXPORTER_PASS="${EXPORTER_PASS}" \
+        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix(${SOCKET})" "${EXPORTER_OPTS[@]}"
 else
     # When running as a snap, expect `exporter.user` and `exporter.password`
     EXPORTER_USER="$(snapctl get exporter.user)"
@@ -43,6 +44,6 @@ else
         --reuid snap_daemon \
         --regid snap_daemon \
         -- \
-        env DATA_SOURCE_NAME="${EXPORTER_USER}:${EXPORTER_PASS}@unix(${SOCKET})/" \
-        "$EXPORTER_PATH" "${EXPORTER_OPTS[@]}"
+        env MYSQLD_EXPORTER_PASSWORD="${EXPORTER_PASS}" \
+        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix(${SOCKET})" "${EXPORTER_OPTS[@]}"
 fi

--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -17,26 +17,25 @@ EXPORTER_OPTS=(
 EXPORTER_PATH="/usr/bin/prometheus-mysqld-exporter"
 SOCKET="/var/run/mysqld/mysqld.sock"
 
-if [ -z "$SNAP" ]; then
-    # When not running as a snap, expect `EXPORTER_USER` and `EXPORTER_PASS` to be set.
-    if [ -z "$EXPORTER_USER" || -z "$EXPORTER_PASS" ]; then
-        echo "EXPORTER_USER and EXPORTER_PASS must be set"
-        exit 1
-    fi
-    exec env MYSQLD_EXPORTER_PASS="${EXPORTER_PASS}" \
-        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix://${SOCKET}" "${EXPORTER_OPTS[@]}"
-else
+if [ -n "$SNAP" ]; then
     # When running as a snap, expect `exporter.user` and `exporter.password`
     EXPORTER_USER="$(snapctl get exporter.user)"
     EXPORTER_PASS="$(snapctl get exporter.password)"
-    EXPORTER_PATH="${SNAP}${EXPORTER_PATH}"
     SOCKET="${SNAP_COMMON}${SOCKET}"
+fi
 
-    if [[ -z "$EXPORTER_USER" || -z "$EXPORTER_PASS" ]]; then
-        echo "exporter.user and exporter.password must be set"
-        exit 1
-    fi
 
+if [ -z "${EXPORTER_USER}" ] || [ -z "${EXPORTER_PASS}" ]; then
+    echo "Error: both EXPORTER_USER and EXPORTER_PASS must be set" >&2
+    exit 1
+fi
+DATA_SOURCE_NAME="${EXPORTER_USER}:${EXPORTER_PASS}@unix(${SOCKET})"
+
+if [ -z "$SNAP" ]; then
+    exec env DATA_SOURCE_NAME="${DATA_SOURCE_NAME}" \
+        "${EXPORTER_PATH}" \
+        "${EXPORTER_OPTS[@]}"
+else
     # For security measures, daemons should not be run as sudo.
     # Execute mysqld-exporter as the non-sudo user: snap-daemon.
     exec "$SNAP"/usr/bin/setpriv \
@@ -44,6 +43,7 @@ else
         --reuid snap_daemon \
         --regid snap_daemon \
         -- \
-        env MYSQLD_EXPORTER_PASSWORD="${EXPORTER_PASS}" \
-        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix://${SOCKET}" "${EXPORTER_OPTS[@]}"
+        env DATA_SOURCE_NAME="${DATA_SOURCE_NAME}" \
+        "${SNAP}${EXPORTER_PATH}" \
+        "${EXPORTER_OPTS[@]}"
 fi

--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -24,7 +24,7 @@ if [ -z "$SNAP" ]; then
         exit 1
     fi
     exec env MYSQLD_EXPORTER_PASS="${EXPORTER_PASS}" \
-        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix(${SOCKET})" "${EXPORTER_OPTS[@]}"
+        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix://${SOCKET}" "${EXPORTER_OPTS[@]}"
 else
     # When running as a snap, expect `exporter.user` and `exporter.password`
     EXPORTER_USER="$(snapctl get exporter.user)"
@@ -45,5 +45,5 @@ else
         --regid snap_daemon \
         -- \
         env MYSQLD_EXPORTER_PASSWORD="${EXPORTER_PASS}" \
-        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix(${SOCKET})" "${EXPORTER_OPTS[@]}"
+        "$EXPORTER_PATH" "--mysqld.username=${EXPORTER_USER}" "--mysqld.address=unix://${SOCKET}" "${EXPORTER_OPTS[@]}"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,7 @@ parts:
       - mysql-server-8.0=8.0.36-0ubuntu0.22.04.1
       - mysql-router=8.0.36-0ubuntu0.22.04.1
       - mysql-shell=8.0.36+dfsg-0ubuntu0.22.04.1~ppa4
-      - prometheus-mysqld-exporter=0.15.0-0ubuntu0.22.04.1~ppa1
+      - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
       - xtrabackup=8.0.35-30-0ubuntu0.22.04.1~ppa1
       - util-linux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,7 +132,7 @@ parts:
       - mysql-router=8.0.36-0ubuntu0.22.04.1
       - mysql-shell=8.0.36+dfsg-0ubuntu0.22.04.1~ppa4
       - prometheus-mysqld-exporter=0.15.0-0ubuntu0.22.04.1~ppa1
-      - prometheus-mysqlrouter-exporter=4.0.5-0ubuntu0.22.04.1~ppa1
+      - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
       - xtrabackup=8.0.35-30-0ubuntu0.22.04.1~ppa1
       - util-linux
     organize:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,7 @@ parts:
       - mysql-server-8.0=8.0.36-0ubuntu0.22.04.1
       - mysql-router=8.0.36-0ubuntu0.22.04.1
       - mysql-shell=8.0.36+dfsg-0ubuntu0.22.04.1~ppa4
-      - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa1
+      - prometheus-mysqld-exporter=0.15.0-0ubuntu0.22.04.1~ppa1
       - prometheus-mysqlrouter-exporter=4.0.5-0ubuntu0.22.04.1~ppa1
       - xtrabackup=8.0.35-30-0ubuntu0.22.04.1~ppa1
       - util-linux

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -80,6 +80,7 @@ def test_all_services():
                 "mysqlrouter-exporter.user": "user",
                 "mysqlrouter-exporter.password": "password",
                 "mysqlrouter-exporter.url": "http://127.0.0.1:8081",
+                "mysqlrouter-exporter.service-name": "mysql-router/0",
             },
         }
 


### PR DESCRIPTION
## Issues
1. To rebuild the snap, we need to update the mysqld-exporter to v0.15 (as our PPA got updated)
2. We need to support TLS for mysql-router-exporter in vms

## Solutions
1. Update mysqld-exporter version that is downloaded. Update the args being passed to mysqld-exporter as breaking changes were introduced in v0.15
2. Add ability to pass router TLS cert, ca and key paths to be then passed to mysql-router-exporter 