### PR TITLE
Upgrade snap to use mysql version 8.0.37

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
-version: '8.0.36' # just for humans, typically '1.2+git' or '1.3.2'
+version: '8.0.37' # just for humans, typically '1.2+git' or '1.3.2'
 summary: MySQL server in a snap. # 79 char long summary
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -128,9 +128,9 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.36-0ubuntu0.22.04.1
-      - mysql-router=8.0.36-0ubuntu0.22.04.1
-      - mysql-shell=8.0.36+dfsg-0ubuntu0.22.04.1~ppa4
+      - mysql-server-8.0=8.0.37-0ubuntu0.22.04.3
+      - mysql-router=8.0.37-0ubuntu0.22.04.31
+      - mysql-shell=8.0.37+dfsg-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
       - xtrabackup=8.0.35-30-0ubuntu0.22.04.1~ppa1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,7 +129,7 @@ parts:
     plugin: nil
     stage-packages:
       - mysql-server-8.0=8.0.37-0ubuntu0.22.04.3
-      - mysql-router=8.0.37-0ubuntu0.22.04.31
+      - mysql-router=8.0.37-0ubuntu0.22.04.3
       - mysql-shell=8.0.37+dfsg-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1


### PR DESCRIPTION
## Issue
We can no longer re-build the snap because mysql versions 8.0.37 are available, and support for 8.0.36 is dropped from deb packages.

## Solution
Upgrade to use 8.0.37