### PR TITLE
[DPE-4173] Add ability to customize router exporter listen port

### DIFF
--- a/snap/local/start-mysql-router-exporter.sh
+++ b/snap/local/start-mysql-router-exporter.sh
@@ -14,6 +14,7 @@ EXPORTER_OPTS=(
 EXPORTER_PATH="/usr/bin/mysqlrouter_exporter"
 
 if [ -n "$SNAP" ]; then
+    MYSQLROUTER_EXPORTER_LISTEN_PORT="$(snapctl get mysqlrouter-exporter.listen-port)"
     MYSQLROUTER_EXPORTER_USER="$(snapctl get mysqlrouter-exporter.user)"
     MYSQLROUTER_EXPORTER_PASS="$(snapctl get mysqlrouter-exporter.password)"
     MYSQLROUTER_EXPORTER_URL="$(snapctl get mysqlrouter-exporter.url)"
@@ -58,6 +59,11 @@ if [ -z "${MYSQLROUTER_EXPORTER_SERVICE_NAME}" ]; then
         echo "Error: MYSQLROUTER_EXPORTER_SERVICE_NAME must be set" >&2
     fi
     exit 1
+fi
+
+# Modify the listen-port if supplied
+if [ -n "${MYSQLROUTER_EXPORTER_LISTEN_PORT}" ]; then
+    EXPORTER_OPTS+=("--listen-port=${MYSQLROUTER_EXPORTER_LISTEN_PORT}")
 fi
 
 # Execute the mysqlrouter_exporter command 


### PR DESCRIPTION
## Issue
The default router exporter listen port in `mysqlrotuer-exporter versions < 6.0.0` is 49152 (which is an ephemeral port that is occasionally used by MySQLRouter to connect to MySQL) leading to port conflicts with MySQLRouter.

## Solution
Add ability to specify a custom listen port in the snap/rock 