### PR TITLE
DPE-5063 Add audit_plugin test | Update server/router

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,24 @@ jobs:
           merge-multiple: true
       - name: Run tests
         run: tox run -e smoke
+
+  smoke:
+    name: Audit log plugin test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - lint
+      - check-version
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install tox
+        run: pipx install tox
+      - name: Download snap package(s)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
+      - name: Run tests
+        run: tox run -e audit_log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Run tests
         run: tox run -e smoke
 
-  smoke:
+  audit-log-plugin:
     name: Audit log plugin test
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.snap
 *pycache*
+venv/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: core22
-version: '8.0.37'
+version: '8.0.39'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -126,8 +126,8 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.37-0ubuntu0.22.04.3
-      - mysql-router=8.0.37-0ubuntu0.22.04.3
+      - mysql-server-8.0=8.0.39-0ubuntu0.22.04.3
+      - mysql-router=8.0.39-0ubuntu0.22.04.3
       - mysql-shell=8.0.37+dfsg-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -126,8 +126,8 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.39-0ubuntu0.22.04.3
-      - mysql-router=8.0.39-0ubuntu0.22.04.3
+      - mysql-server-8.0=8.0.39-0ubuntu0.22.04.1
+      - mysql-router=8.0.39-0ubuntu0.22.04.1
       - mysql-shell=8.0.37+dfsg-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+COMMON="/var/snap/charmed-mysql/common"
+CURRENT="/var/snap/charmed-mysql/current"
+
+charmed-mysql.mysqlsh --help
+touch ${COMMON}/var/log/mysql/error.log
+chown -R snap_daemon ${COMMON}
+
+
+cat <<EOF > ${CURRENT}/etc/mysql/mysql.conf.d/alter_pass.sql
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'newpass';
+FLUSH PRIVILEGES;
+EOF
+
+cat <<EOF > ${CURRENT}/etc/mysql/mysql.conf.d/temp_init.cnf
+[mysqld]
+init_file=/var/snap/charmed-mysql/current/etc/mysql/mysql.conf.d/alter_pass.sql
+loose-audit_log_format = JSON
+EOF
+
+
+chown -R snap_daemon ${CURRENT}/etc/mysql/mysql.conf.d/*
+
+snap start charmed-mysql.mysqld
+sleep 2
+snap restart charmed-mysql.mysqld
+sleep 2
+
+snap alias charmed-mysql.mysql mysql
+

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -19,6 +19,7 @@ cat <<EOF > ${CURRENT}/etc/mysql/mysql.conf.d/temp_init.cnf
 [mysqld]
 init_file=/var/snap/charmed-mysql/current/etc/mysql/mysql.conf.d/alter_pass.sql
 loose-audit_log_format = JSON
+loose-audit_log_strategy = SYNCHRONOUS
 EOF
 
 

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,64 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import yaml
+import subprocess
+import pytest
+
+COMMON = "/var/snap/charmed-mysql/common"
+CURRENT = "/var/snap/charmed-mysql/current"
+
+
+def test_install():
+    with open("snap/snapcraft.yaml") as file:
+        snapcraft = yaml.safe_load(file)
+
+        subprocess.run(
+            f"sudo snap remove --purge {snapcraft['name']}".split(),
+            check=True,
+        )
+
+        subprocess.run(
+            f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --devmode".split(),
+            check=True,
+        )
+
+
+@pytest.mark.run(after="test_install")
+def test_setup():
+    # run initialization script
+    subprocess.run(["sudo", "tests/setup.sh"], check=True)
+
+
+@pytest.mark.run(after="test_setup")
+def test_install_audit_plugin():
+    # install audit plugin
+    command = [
+        "mysql",
+        "-u",
+        "root",
+        "--password=newpass",
+        "-S",
+        f"{COMMON}/var/run/mysqld/mysqld.sock",
+        "-e",
+        "INSTALL PLUGIN audit_log SONAME 'audit_log.so'",
+    ]
+
+    subprocess.run(
+        command,
+        check=True,
+    )
+
+
+@pytest.mark.run(after="test_install_audit_plugin")
+def test_audit_log_file():
+    # Ensure file is readable
+    audit_file = f"{COMMON}/var/lib/mysql/audit.log"
+    subprocess.run(["sudo", "chmod", "644", audit_file], check=True)
+
+    with open(audit_file) as f:
+        content = f.read()
+
+    # assert last record is a `Quit` from previous command
+    assert json.loads(content.splitlines()[-1])["audit_record"]["name"] == "Quit"

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -14,15 +14,14 @@ def test_install():
     with open("snap/snapcraft.yaml") as file:
         snapcraft = yaml.safe_load(file)
 
-        subprocess.run(
-            f"sudo snap remove --purge {snapcraft['name']}".split(),
-            check=True,
-        )
-
-        subprocess.run(
-            f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --devmode".split(),
-            check=True,
-        )
+    subprocess.run(
+        f"sudo snap remove --purge {snapcraft['name']}".split(),
+        check=True,
+    )
+    subprocess.run(
+        f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --devmode".split(),
+        check=True,
+    )
 
 
 @pytest.mark.run(after="test_install")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import yaml
 import subprocess
 import time

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,11 @@ deps =
     pyyaml
 commands =
     pytest -vv --no-header --tb native --log-cli-level=INFO tests/test_smoke.py -s
+
+[testenv:audit_log]
+description = functional test for audit log plugin
+deps =
+    pytest
+    pyyaml
+commands =
+    pytest -vv --no-header --tb native --log-cli-level=INFO tests/test_audit_log.py -s


### PR DESCRIPTION
Include a functional test to ensure audit_plugin will keep working and early catch when not.
Update router/server (8.0.39) since 8.0.37 no longer available on archives.
