### PR TITLE
Install libprotobuf32 from PPA + update percona-xtrabackup version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,8 +29,6 @@ package-repositories:
     ppa: data-platform/mysqld-exporter
   - type: apt
     ppa: data-platform/mysqlrouter-exporter
-  - type: apt
-    ppa: data-platform/mysql-archive # needed for libprotobuf32
 
 layout:
   /var/lib/mysql-files:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ package-repositories:
   - type: apt
     ppa: data-platform/mysqlrouter-exporter
   - type: apt
-    ppa: data-platform/mysql-archive
+    ppa: data-platform/mysql-archive # needed for libprotobuf32
 
 layout:
   /var/lib/mysql-files:
@@ -130,7 +130,6 @@ parts:
     stage-packages:
       - mysql-server-8.0=8.0.39-0ubuntu0.22.04.1
       - mysql-router=8.0.39-0ubuntu0.22.04.1
-      - libprotobuf32=3.21.12-3ubuntu0.22.04.1~ppa1
       - mysql-shell=8.0.37+dfsg-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,8 @@ package-repositories:
     ppa: data-platform/mysqld-exporter
   - type: apt
     ppa: data-platform/mysqlrouter-exporter
+  - type: apt
+    ppa: data-platform/mysql-archive
 
 layout:
   /var/lib/mysql-files:
@@ -128,10 +130,11 @@ parts:
     stage-packages:
       - mysql-server-8.0=8.0.39-0ubuntu0.22.04.1
       - mysql-router=8.0.39-0ubuntu0.22.04.1
+      - libprotobuf32=3.21.12-3ubuntu0.22.04.1~ppa1
       - mysql-shell=8.0.37+dfsg-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
-      - xtrabackup=8.0.35-30-0ubuntu0.22.04.1~ppa1
+      - percona-xtrabackup=8.0.35-31-0ubuntu0.22.04.1~ppa3
       - util-linux
     organize:
       usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
@@ -139,7 +142,7 @@ parts:
       usr/share/doc/mysqlsh/LICENSE.gz: licenses/LICENSE-mysql-shell
       usr/share/doc/prometheus-mysqld-exporter/copyright: licenses/COPYRIGHT-prometheus-mysqld-exporter
       usr/share/doc/prometheus-mysqlrouter-exporter/copyright: licenses/COPYRIGHT-prometheus-mysqlrouter-exporter
-      usr/share/doc/xtrabackup/LICENSE.gz: licenses/LICENSE-xtrabackup
+      usr/share/doc/percona-xtrabackup/LICENSE.gz: licenses/LICENSE-percona-xtrabackup
       usr/share/doc/util-linux/copyright: licenses/COPYRIGHT-util-linux
   audit-plugin:
     plugin: nil


### PR DESCRIPTION
## Issues
1. We need to update the `xtrabackup` package, along with a rename of the package to `percona-xtrabackup`

## Solution
1. Update the version, along with renaming the package
