### PR TITLE
Update mysql-shell to a new build of 8.0.38 with fresh build of dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,7 +128,7 @@ parts:
     stage-packages:
       - mysql-server-8.0=8.0.39-0ubuntu0.22.04.1
       - mysql-router=8.0.39-0ubuntu0.22.04.1
-      - mysql-shell=8.0.37+dfsg-0ubuntu0.22.04.1~ppa3
+      - mysql-shell=8.0.38+dfsg-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
       - percona-xtrabackup=8.0.35-31-0ubuntu0.22.04.1~ppa3


### PR DESCRIPTION
## Issue
Since we discovered that `mysql-shell` relies on `libprotobuf32` (which was previously retrieved from the `xtrabackup` PPA), and given the fact that we removed `libprotobuf32` from the `xtrabackup` PPA (as xtrabackup does not rely on it), we want to rebuild mysql-shell with libprotobuf to use a fresh build in our snap.

## Solution
Use freshly rebuilt packages in the snap