### PR TITLE
Point-In-Time-Recovery

### DIFF
--- a/snap/local/start-mysql-pitr-helper-collector.sh
+++ b/snap/local/start-mysql-pitr-helper-collector.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+exec "${SNAP}/usr/bin/mysql-pitr-helper" \
+    collect \
+    "${SNAP_DATA}/etc/mysql-pitr-helper-collector.yaml"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,10 @@ apps:
     command: usr/bin/mysql
     plugs:
       - network
+  mysqlbinlog:
+    command: usr/bin/mysqlbinlog
+    plugs:
+      - network
   mysqld:
     command: start-mysqld.sh
     daemon: simple
@@ -123,6 +127,16 @@ apps:
       - network-bind
   mysqlrouter-passwd:
     command: run-mysql-router-password.sh
+  mysql-pitr-helper:
+    command: usr/bin/mysql-pitr-helper
+    plugs:
+      - network
+  mysql-pitr-helper-collector:
+    command: start-mysql-pitr-helper-collector.sh
+    daemon: simple
+    install-mode: disable
+    plugs:
+      - network
 
 parts:
   packages-deb:
@@ -136,6 +150,7 @@ parts:
       - percona-xtrabackup=8.0.35-31-0ubuntu0.22.04.1~ppa3
       - util-linux
       - mysql-8.0-binlog-utils-udf
+      - mysql-pitr-helper
     organize:
       usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
       usr/share/doc/mysql-router/LICENSE.router.gz: licenses/LICENSE-mysql-router

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,8 +79,6 @@ apps:
       - network
   mysqlbinlog:
     command: usr/bin/mysqlbinlog
-    plugs:
-      - network
   mysqld:
     command: start-mysqld.sh
     daemon: simple

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,8 @@ package-repositories:
     ppa: data-platform/mysqld-exporter
   - type: apt
     ppa: data-platform/mysqlrouter-exporter
+  - type: apt
+    ppa: zvirovyi/ppa
 
 layout:
   /var/lib/mysql-files:
@@ -133,6 +135,7 @@ parts:
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
       - percona-xtrabackup=8.0.35-31-0ubuntu0.22.04.1~ppa3
       - util-linux
+      - mysql-8.0-binlog-utils-udf
     organize:
       usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
       usr/share/doc/mysql-router/LICENSE.router.gz: licenses/LICENSE-mysql-router


### PR DESCRIPTION
Temporary add `binlog_utils_udf` plugin (`mysql-8.0-binlog-utils-udf` deb package) and `mysql-pitr-helper` (https://github.com/canonical/mysql-pitr-helper) from my PPA for the Point-In-Time-Recovery work until Data Platform merges it.
Also, make `mysqlbinlog` public that required for the `mysql-pitr-helper`.