### PR TITLE
[DPE-6139] Update mysql and router to 8.0.40 + install percona server plugins from PPA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
 
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v16
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v24.0.6
 
   smoke:
     name: Smoke test snap

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,13 +14,13 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v16
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v24.0.6
 
   release:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v16
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v24.0.6
     with:
       channel: 8.0/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/snap/local/start-mysql-pitr-helper-collector.sh
+++ b/snap/local/start-mysql-pitr-helper-collector.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# For security measures, applications should not be run as sudo.
+# Execute mysqlsh as the non-sudo user: snap-daemon.
+exec "${SNAP}/usr/bin/setpriv" \
+  --clear-groups \
+  --reuid snap_daemon \
+  --regid snap_daemon \
+  -- \
+  "${SNAP}/usr/bin/mysql-pitr-helper" \
+  collect \
+  "${SNAP_DATA}/etc/mysql-pitr-helper-collector.yaml"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,6 +90,18 @@ apps:
     command: run-mysqlsh.sh
     plugs:
       - network
+  mysqlbinlog:
+    command: usr/bin/mysqlbinlog
+  mysql-pitr-helper:
+    command: usr/bin/mysql-pitr-helper
+    plugs:
+      - network
+  mysql-pitr-helper-collector:
+    command: start-mysql-pitr-helper-collector.sh
+    daemon: simple
+    install-mode: disable
+    plugs:
+      - network
   mysqlrouter:
     command: run-mysql-router.sh
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: core22
-version: '8.0.39'
+version: '8.0.40'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -130,7 +130,7 @@ parts:
     stage-packages:
       - mysql-server-8.0=8.0.40-0ubuntu0.22.04.1
       - mysql-router=8.0.40-0ubuntu0.22.04.1
-      - mysql-shell=8.0.38+dfsg-0ubuntu0.22.04.1~ppa2
+      - mysql-shell=8.0.40+dfsg-0ubuntu0.22.04.1~ppa4
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
       - percona-xtrabackup=8.0.35-31-0ubuntu0.22.04.1~ppa3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,8 @@ package-repositories:
     ppa: data-platform/mysqlrouter-exporter
   - type: apt
     ppa: data-platform/percona-server-plugins
+  - type: apt
+    ppa: data-platform/mysql-pitr-helper
 
 layout:
   /var/lib/mysql-files:
@@ -138,6 +140,7 @@ parts:
       - mysql-audit-log-plugin=8.0.39+dfsg-0ubuntu0.22.04.1~ppa6
       - mysql-auth-ldap-plugin=8.0.39+dfsg-0ubuntu0.22.04.1~ppa6
       - mysql-binlog-utils-udf-plugin=8.0.39+dfsg-0ubuntu0.22.04.1~ppa6
+      - mysql-pitr-helper=2-0ubuntu0.22.04.1~ppa1
       - util-linux
     organize:
       usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
@@ -150,6 +153,7 @@ parts:
       usr/share/doc/mysql-audit-log-plugin/copyright: licenses/COPYRIGHT-mysql-audit-log-plugin
       usr/share/doc/mysql-auth-ldap-plugin/copyright: licenses/COPYRIGHT-mysql-auth-ldap-plugin
       usr/share/doc/mysql-binlog-utils-udf-plugin/copyright: licenses/COPYRIGHT-mysql-binlog-utils-udf-plugin
+      usr/share/doc/mysql-pitr-helper/copyright: licenses/COPYRIGHT-mysql-pitr-helper
       usr/share/doc/util-linux/copyright: licenses/COPYRIGHT-util-linux
   snap-license:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,8 @@ package-repositories:
     ppa: data-platform/mysqld-exporter
   - type: apt
     ppa: data-platform/mysqlrouter-exporter
+  - type: apt
+    ppa: data-platform/percona-server-plugins
 
 layout:
   /var/lib/mysql-files:
@@ -126,12 +128,16 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.39-0ubuntu0.22.04.1
-      - mysql-router=8.0.39-0ubuntu0.22.04.1
+      - mysql-server-8.0=8.0.40-0ubuntu0.22.04.1
+      - mysql-router=8.0.40-0ubuntu0.22.04.1
       - mysql-shell=8.0.38+dfsg-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa1
       - percona-xtrabackup=8.0.35-31-0ubuntu0.22.04.1~ppa3
+      - mysql-audit-log-filter-plugin=8.0.39+dfsg-0ubuntu0.22.04.1~ppa6
+      - mysql-audit-log-plugin=8.0.39+dfsg-0ubuntu0.22.04.1~ppa6
+      - mysql-auth-ldap-plugin=8.0.39+dfsg-0ubuntu0.22.04.1~ppa6
+      - mysql-binlog-utils-udf-plugin=8.0.39+dfsg-0ubuntu0.22.04.1~ppa6
       - util-linux
     organize:
       usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
@@ -140,36 +146,11 @@ parts:
       usr/share/doc/prometheus-mysqld-exporter/copyright: licenses/COPYRIGHT-prometheus-mysqld-exporter
       usr/share/doc/prometheus-mysqlrouter-exporter/copyright: licenses/COPYRIGHT-prometheus-mysqlrouter-exporter
       usr/share/doc/percona-xtrabackup/LICENSE.gz: licenses/LICENSE-percona-xtrabackup
+      usr/share/doc/mysql-audit-log-filter-plugin/copyright: licenses/COPYRIGHT-mysql-audit-log-filter-plugin
+      usr/share/doc/mysql-audit-log-plugin/copyright: licenses/COPYRIGHT-mysql-audit-log-plugin
+      usr/share/doc/mysql-auth-ldap-plugin/copyright: licenses/COPYRIGHT-mysql-auth-ldap-plugin
+      usr/share/doc/mysql-binlog-utils-udf-plugin/copyright: licenses/COPYRIGHT-mysql-binlog-utils-udf-plugin
       usr/share/doc/util-linux/copyright: licenses/COPYRIGHT-util-linux
-  audit-plugin:
-    plugin: nil
-    after: [packages-deb]
-    build-packages:
-      - rpm
-    build-environment:
-      - VERSION: 8.0.36-28
-      - BASE_AMD64: Percona-Server-${VERSION}-Linux.x86_64.glibc2.35.tar.gz
-      - BASE_ARM64: percona-server-server-${VERSION}.1.el9.aarch64.rpm
-      - DIR_URL: https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-${VERSION}/binary
-      - PATH_AMD64: tarball
-      - PATH_ARM64: redhat/9/aarch64
-      - LICENSE_URL: https://raw.githubusercontent.com/percona/percona-server/8.0/LICENSE
-    override-pull: |
-      if [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
-        URL=${DIR_URL}/${PATH_ARM64}/${BASE_ARM64}
-        curl -o file.rpm "${URL}"
-        # output a file.rpm.tgz
-        rpm2archive file.rpm
-        tar -xf file.rpm.tgz --strip-components 4 --wildcards --no-anchored '*audit_log*.so*'
-      else
-        URL=${DIR_URL}/${PATH_AMD64}/${BASE_AMD64}
-        curl -o file.tar.gz "${URL}"
-        tar -xf  file.tar.gz --strip-components 2 --wildcards --no-anchored '*audit_log*.so*'
-      fi
-      curl -o LICENSE "${LICENSE_URL}"
-    override-prime: |
-      cp ${SNAPCRAFT_PART_BUILD}/plugin/*.so ${SNAPCRAFT_PRIME}/usr/lib/mysql/plugin/
-      cp ${SNAPCRAFT_PART_BUILD}/LICENSE ${SNAPCRAFT_PRIME}/licenses/LICENSE-audit-plugin
   snap-license:
     plugin: dump
     source: .

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -21,6 +21,11 @@ def test_install():
             check=True,
         )
 
+        subprocess.run(
+            f"sudo  install -o snap_daemon /dev/null /var/snap/{snapcraft['name']}/common/var/log/mysql/error.log".split(),
+            check=True,
+        )
+
 
 @pytest.mark.run(after="test_install")
 def test_all_apps():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -33,9 +33,11 @@ def test_all_apps():
         }
 
         sudo = ["mysqlrouter", "mysqlsh", "mysqlrouter-passwd"]
+        # pitr helper requires s3 credentials
+        skip = ["mysql-pitr-helper"]
 
         for app, data in snapcraft["apps"].items():
-            if not bool(data.get("daemon")):
+            if not bool(data.get("daemon")) and app not in skip:
                 print(f"Testing {snapcraft['name']}.{app}....")
                 subprocess.run(
                     f"{'sudo' if app in sudo else ''} {snapcraft['name']}.{app} {override.get(app, '--help')}".split(),
@@ -49,17 +51,32 @@ def test_all_services():
         snapcraft = yaml.safe_load(file)
 
         subprocess.run(
-            f"sudo cp tests/mysqlrouter.conf /var/snap/{snapcraft['name']}/current/etc/mysqlrouter/mysqlrouter.conf".split(),
+            [
+                "sudo",
+                "install",
+                "-o",
+                "snap_daemon",
+                "-m",
+                "600",
+                "tests/mysqlrouter.conf",
+                f"/var/snap/{snapcraft['name']}/current/etc/mysqlrouter/mysqlrouter.conf",
+            ],
             check=True,
         )
         subprocess.run(
-            f"sudo {snapcraft['name']}.mysqlrouter-passwd set /var/snap/{snapcraft['name']}/current/etc/mysqlrouter/mysqlrouter.pwd user".split(),
+            [
+                "sudo",
+                f"{snapcraft['name']}.mysqlrouter-passwd",
+                "set",
+                f"/var/snap/{snapcraft['name']}/current/etc/mysqlrouter/mysqlrouter.pwd",
+                "user",
+            ],
             input="password",
             encoding="utf-8",
             check=True,
         )
 
-        skip = ["mysqlrouter-service"]
+        skip = ["mysqlrouter-service", "mysql-pitr-helper-collector"]
 
         subprocess.run(
             f"sudo snap start {snapcraft['name']}.mysqlrouter-service".split(),
@@ -72,7 +89,9 @@ def test_all_services():
             capture_output=True,
             encoding="utf-8",
         )
-        assert "active" == service.stdout.split("\n")[1].split()[2]
+        assert (
+            "active" == service.stdout.split("\n")[1].split()[2]
+        ), "Failed to start mysql-router service"
 
         service_configs = {
             "mysqld-exporter": {
@@ -98,16 +117,17 @@ def test_all_services():
                             check=True,
                         )
 
-                subprocess.run(
-                    f"sudo snap start {snapcraft['name']}.{app}".split(), check=True
-                )
+                service_name = f"{snapcraft['name']}.{app}"
+                subprocess.run(f"sudo snap start {service_name}".split(), check=True)
                 time.sleep(5)
                 service = subprocess.run(
-                    f"snap services {snapcraft['name']}.{app}".split(),
+                    f"snap services {service_name}".split(),
                     check=True,
                     capture_output=True,
                     encoding="utf-8",
                 )
-                subprocess.run(f"sudo snap stop {snapcraft['name']}.{app}".split())
+                subprocess.run(f"sudo snap stop {service_name}".split())
 
-                assert "active" == service.stdout.split("\n")[1].split()[2]
+                assert (
+                    "active" == service.stdout.split("\n")[1].split()[2]
+                ), f"Failed to start {service_name}"


### PR DESCRIPTION
## Issue
1. MySQL 8.0.40 is out and so we need to update the `mysql-server-8.0` and `myslq-router` packages
2. We have a PPA with all the percona server plugins

## Solution
1. Update MySQL to 8.0.40
2. Install percona server plugins from the PPA instead

## TODO before merging
~~Rebuild the mysql-shell PPA for v8.0.40, and update the mysql-shell plugin to this compatible version~~