### PR TITLE
Fix mysql-pitr-helper-collector

### DIFF
--- a/snap/local/start-mysql-pitr-helper-collector.sh
+++ b/snap/local/start-mysql-pitr-helper-collector.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-# For security measures, applications should not be run as sudo.
-# Execute mysqlsh as the non-sudo user: snap-daemon.
-exec "${SNAP}/usr/bin/setpriv" \
-  --clear-groups \
-  --reuid snap_daemon \
-  --regid snap_daemon \
-  -- \
-  "${SNAP}/usr/bin/mysql-pitr-helper" \
-  collect \
-  "${SNAP_DATA}/etc/mysql-pitr-helper-collector.yaml"
+if [ -z "$SNAP" ]; then
+    exec "/usr/bin/mysql-pitr-helper" \
+        collect \
+        "/etc/mysql-pitr-helper-collector.yaml"
+else
+    # For security measures, applications should not be run as sudo.
+    # Execute mysqlsh as the non-sudo user: snap-daemon.
+    exec "${SNAP}/usr/bin/setpriv" \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid snap_daemon \
+        -- \
+        "${SNAP}/usr/bin/mysql-pitr-helper" \
+        collect \
+        "${SNAP_DATA}/etc/mysql-pitr-helper-collector.yaml"
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,6 +100,7 @@ apps:
     command: start-mysql-pitr-helper-collector.sh
     daemon: simple
     install-mode: disable
+    restart-delay: 2m
     plugs:
       - network
   mysqlrouter:


### PR DESCRIPTION
1. K8s will fail on `snap_daemon` in `start-mysql-pitr-helper-collector.sh`, so implemented the same approach as in `start-mysqld-exporter.sh` to check on `$SNAP` variable.
2. Add `restart-delay: 2m` for service. This is useful when cluster is temporary unavailable, so `mysql-pitr-helper-collector` will try to restart with reasonable delay. For example, now on VM you can do `lxc restart --all` and on cluster startup, `mysql-pitr-helper-collector` will fail to start as `mysqld` isn't ready immediately. It will lead to the next error (5 restarts within several seconds):
    ```
    2025-01-23T11:11:27Z systemd[1]: snap.charmed-mysql.mysql-pitr-helper-collector.service: Main process exited, code=exited, status=1/FAILURE
    2025-01-23T11:11:27Z systemd[1]: snap.charmed-mysql.mysql-pitr-helper-collector.service: Failed with result 'exit-code'.
    2025-01-23T11:11:27Z systemd[1]: snap.charmed-mysql.mysql-pitr-helper-collector.service: Scheduled restart job, restart counter is at 5.
    2025-01-23T11:11:27Z systemd[1]: Stopped Service for snap application charmed-mysql.mysql-pitr-helper-collector.
    2025-01-23T11:11:27Z systemd[1]: snap.charmed-mysql.mysql-pitr-helper-collector.service: Start request repeated too quickly.
    2025-01-23T11:11:27Z systemd[1]: snap.charmed-mysql.mysql-pitr-helper-collector.service: Failed with result 'exit-code'.
    2025-01-23T11:11:27Z systemd[1]: Failed to start Service for snap application charmed-mysql.mysql-pitr-helper-collector.
    ```