### PR TITLE
Env config for mysql-pitr-helper-collector

### DIFF
--- a/snap/local/start-mysql-pitr-helper-collector.sh
+++ b/snap/local/start-mysql-pitr-helper-collector.sh
@@ -2,8 +2,7 @@
 
 if [ -z "$SNAP" ]; then
     exec "/usr/bin/mysql-pitr-helper" \
-        collect \
-        "/etc/mysql-pitr-helper-collector.yaml"
+        collect
 else
     # For security measures, applications should not be run as sudo.
     # Execute mysqlsh as the non-sudo user: snap-daemon.
@@ -12,7 +11,24 @@ else
         --reuid snap_daemon \
         --regid snap_daemon \
         -- \
+        env HOSTS="$(snapctl get mysql-pitr-helper-collector.hosts)" \
+        env USER="$(snapctl get mysql-pitr-helper-collector.user)" \
+        env PASS="$(snapctl get mysql-pitr-helper-collector.pass)" \
+        env STORAGE_TYPE="$(snapctl get mysql-pitr-helper-collector.storage-type)" \
+        env BUFFER_SIZE="$(snapctl get mysql-pitr-helper-collector.buffer-size)" \
+        env COLLECT_SPAN_SEC="$(snapctl get mysql-pitr-helper-collector.collect-span-sec)" \
+        env VERIFY_TLS="$(snapctl get mysql-pitr-helper-collector.verify-tls)" \
+        env TIMEOUT_SECONDS="$(snapctl get mysql-pitr-helper-collector.timeout-seconds)" \
+        env ENDPOINT="$(snapctl get mysql-pitr-helper-collector.endpoint)" \
+        env ACCESS_KEY_ID="$(snapctl get mysql-pitr-helper-collector.access-key-id)" \
+        env SECRET_ACCESS_KEY="$(snapctl get mysql-pitr-helper-collector.secret-access-key)" \
+        env S3_BUCKET_URL="$(snapctl get mysql-pitr-helper-collector.s3-bucket-url)" \
+        env DEFAULT_REGION="$(snapctl get mysql-pitr-helper-collector.default-region)" \
+        env AZURE_ENDPOINT="$(snapctl get mysql-pitr-helper-collector.azure-endpoint)" \
+        env AZURE_CONTAINER_PATH="$(snapctl get mysql-pitr-helper-collector.azure-container-path)" \
+        env AZURE_STORAGE_CLASS="$(snapctl get mysql-pitr-helper-collector.azure-storage-class)" \
+        env AZURE_STORAGE_ACCOUNT="$(snapctl get mysql-pitr-helper-collector.azure-storage-account)" \
+        env AZURE_ACCESS_KEY="$(snapctl get mysql-pitr-helper-collector.azure-access-key)" \
         "${SNAP}/usr/bin/mysql-pitr-helper" \
-        collect \
-        "${SNAP_DATA}/etc/mysql-pitr-helper-collector.yaml"
+        collect
 fi


### PR DESCRIPTION
Don't use config file but environment variables for the mysql-pitr-helper-collector.
In VM, they will be set with `snap set` in kebab case. In K8s, they will be directly provided through the Pebble.
Proposed by @paulomach. It will improve security as no S3 credentials will be written on the unit disk.