### PR TITLE
Update start-mysqld-exporter.sh

### DIFF
--- a/snap/local/start-mysqld-exporter.sh
+++ b/snap/local/start-mysqld-exporter.sh
@@ -12,6 +12,8 @@ EXPORTER_OPTS=(
     "--no-collect.perf_schema.indexiowaits"
     "--no-collect.perf_schema.tableiowaits"
     "--no-collect.perf_schema.tablelocks"
+    "--collect.perf_schema.replication_group_members"
+    "--collect.perf_schema.replication_group_member_stats"
     "--no-collect.auto_increment.columns"
 )
 EXPORTER_PATH="/usr/bin/prometheus-mysqld-exporter"


### PR DESCRIPTION
The charm currently lacks cluster health monitoring and alerting:
https://github.com/canonical/mysql-k8s-operator/issues/619

This PR enables the necessary exporter flags to have at least some basic cluster health checks.
It's needed for https://github.com/canonical/mysql-k8s-operator/pull/631 to work.