### PR TITLE
[DPE-8300] Update snapcraft.yaml artifact paths

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ system-usernames:
 
 package-repositories:
   - type: apt
-    ppa: data-platform/mysql-shell
+    ppa: data-platform/mysql-shell-8.0
   - type: apt
     ppa: data-platform/xtrabackup
   - type: apt
@@ -32,7 +32,7 @@ package-repositories:
   - type: apt
     ppa: data-platform/mysqlrouter-exporter
   - type: apt
-    ppa: data-platform/percona-server-plugins
+    ppa: data-platform/mysql-server-plugins-8.0
   - type: apt
     ppa: data-platform/mysql-pitr-helper
 
@@ -145,20 +145,20 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.44-0ubuntu0.22.04.1
+      - mysql-server=8.0.44-0ubuntu0.22.04.1
       - mysql-router=8.0.44-0ubuntu0.22.04.1
-      - mysql-shell-8.0=8.0.44+dfsg-0ubuntu0.22.04.1~ppa3
+      - mysql-shell=8.0.44+dfsg-0ubuntu0.22.04.1~ppa2
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa2
       - percona-xtrabackup=8.0.35-32-0ubuntu0.22.04.1~ppa1
-      - mysql-audit-log-filter-plugin-8.0=8.0.44+dfsg1-0ubuntu0.22.04.1~ppa2
-      - mysql-audit-log-plugin-8.0=8.0.44+dfsg1-0ubuntu0.22.04.1~ppa2
-      - mysql-auth-ldap-plugin-8.0=8.0.44+dfsg1-0ubuntu0.22.04.1~ppa2
-      - mysql-binlog-utils-udf-plugin-8.0=8.0.44+dfsg1-0ubuntu0.22.04.1~ppa2
+      - mysql-audit-log-filter-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-audit-log-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-auth-ldap-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-binlog-utils-udf-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
       - mysql-pitr-helper=2-0ubuntu0.22.04.1~ppa1
       - util-linux
     organize:
-      usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
+      usr/share/doc/mysql-server/copyright: licenses/COPYRIGHT-mysql-server
       usr/share/doc/mysql-router/LICENSE.router.gz: licenses/LICENSE-mysql-router
       usr/share/doc/mysqlsh/LICENSE.gz: licenses/LICENSE-mysql-shell
       usr/share/doc/prometheus-mysqld-exporter/copyright: licenses/COPYRIGHT-prometheus-mysqld-exporter


### PR DESCRIPTION
This PR updates the `snapcraft.yaml` artifact paths to point at those that are hosted in the version-awared PPAs:

- [mysql-server-plugins-8.0](https://launchpad.net/~data-platform/+archive/ubuntu/mysql-server-plugins-8.0).
- [mysql-shell-8.0](https://launchpad.net/~data-platform/+archive/ubuntu/mysql-shell-8.0).

---

Unblocks the removal of the old PPAs.