### PR TITLE
[MISC] 8.4 - Revert to mysql-safe as a supervisor process

### DIFF
--- a/snap/local/start-mysqld.sh
+++ b/snap/local/start-mysqld.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # For security measures, applications should not be run as sudo.
-# Execute mysqld as the non-sudo user: snap-daemon
+# Execute mysqld_safe as the non-sudo user: snap-daemon
 # Note: group is set to root due to backups related intricacies.
 exec "${SNAP}/usr/bin/setpriv" \
     --clear-groups \
     --reuid snap_daemon \
     --regid root \
     -- \
-    "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf"
+    "${SNAP}/usr/bin/mysqld_safe" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf"


### PR DESCRIPTION
This PR reverts the vanilla `mysqld` binary back to the provided `mysqld_safe` one, in order to have a _supervisor process_ able to capture the restart exit code, needed for the correct behavior of MySQL when preparing for / joining a cluster. As an alternative, we could create our own shell-script to capture exit code `16`.

---

Reference: https://dev.mysql.com/doc/refman/8.4/en/restart.html