### PR TITLE
[MISC] Touch log-files required by mysqld_safe

### DIFF
--- a/snap/local/start-mysqld.sh
+++ b/snap/local/start-mysqld.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Touch mysqld_safe required log-files
+touch $SNAP_COMMON/var/log/mysql/error.log
+
 # For security measures, applications should not be run as sudo.
 # Execute mysqld_safe as the non-sudo user: snap-daemon
 # Note: group is set to root due to backups related intricacies.

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -2,13 +2,9 @@
 
 set -e
 
-COMMON="/var/snap/charmed-mysql/common"
 CURRENT="/var/snap/charmed-mysql/current"
 
 charmed-mysql.mysqlsh --help
-touch ${COMMON}/var/log/mysql/error.log
-chown -R snap_daemon ${COMMON}
-
 
 cat <<EOF > ${CURRENT}/etc/mysql/mysql.conf.d/alter_pass.sql
 ALTER USER 'root'@'localhost' IDENTIFIED BY 'newpass';
@@ -31,4 +27,3 @@ snap restart charmed-mysql.mysqld
 sleep 2
 
 snap alias charmed-mysql.mysql mysql
-


### PR DESCRIPTION
This PR fixes a subtle bug where, depending on the Ubuntu AppArmor profile settings, the `mysqld_safe` script may not be able to create the necessary log files for it to start-up. Ubuntu 22 is compatible, but Ubuntu 24 is not.

---

Depends on bumping up MySQL 8.0 binaries to use MySQL 8.0.45