### PR TITLE
[MISC] Touch log-files required by mysqld_safe

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -35,6 +35,10 @@ mkdir -p $MYSQL_SHELL_USER_CONFIG
 # Copy over mysql config file
 cp -r $SNAP/etc/mysql $SNAP_DATA/etc/
 
+# Touch mysqld_safe required log-files
+touch $MYSQL_VAR_LOG/error.log
+touch $MYSQL_VAR_LOG/query.log
+
 # Replace default configuration options to work within the snap environment
 sed -i "s:# sock:sock:g" $MYSQLD_CONFIG
 sed -i "s:# datadir:datadir:g" $MYSQLD_CONFIG

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -2,13 +2,9 @@
 
 set -e
 
-COMMON="/var/snap/charmed-mysql/common"
 CURRENT="/var/snap/charmed-mysql/current"
 
 charmed-mysql.mysqlsh --help
-touch ${COMMON}/var/log/mysql/error.log
-chown -R snap_daemon ${COMMON}
-
 
 cat <<EOF > ${CURRENT}/etc/mysql/mysql.conf.d/alter_pass.sql
 ALTER USER 'root'@'localhost' IDENTIFIED BY 'newpass';


### PR DESCRIPTION
This PR fixes a subtle bug where, depending on the Ubuntu AppArmor profile settings, the `mysqld_safe` script may not be able to create the necessary log files for it to start-up. Ubuntu 22 is compatible, but Ubuntu 24 is not.