### PR TITLE
[MISC] Touch log-files required by mysqld_safe

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -35,10 +35,6 @@ mkdir -p $MYSQL_SHELL_USER_CONFIG
 # Copy over mysql config file
 cp -r $SNAP/etc/mysql $SNAP_DATA/etc/
 
-# Touch mysqld_safe required log-files
-touch $MYSQL_VAR_LOG/error.log
-touch $MYSQL_VAR_LOG/query.log
-
 # Replace default configuration options to work within the snap environment
 sed -i "s:# sock:sock:g" $MYSQLD_CONFIG
 sed -i "s:# datadir:datadir:g" $MYSQLD_CONFIG

--- a/snap/local/start-mysqld.sh
+++ b/snap/local/start-mysqld.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 
-# For security measures, applications should not be run as sudo.
-# Execute mysqld_safe as the non-sudo user: snap-daemon
-# Note: group is set to root due to backups related intricacies.
-exec "${SNAP}/usr/bin/setpriv" \
-    --clear-groups \
-    --reuid snap_daemon \
-    --regid root \
-    -- \
-    "${SNAP}/usr/bin/mysqld_safe" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf"
+# This script is designed to be a "supervisor process" for MySQL Server.
+# Such process is needed for it to be able to restart upon config changes.
+# Ref: https://dev.mysql.com/doc/refman/8.4/en/restart.html
+
+export MYSQLD_PARENT_PID=$$
+export MYSQLD_RESTART_CODE=16
+
+while true; do
+    # For security measures, applications should not be run as sudo.
+    # Execute mysqld as the non-sudo user: snap-daemon
+    # Note: group is set to root due to backups related intricacies.
+    exec "${SNAP}/usr/bin/setpriv" \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid root \
+        -- \
+        "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf" &
+
+    wait $!
+
+    EXIT_CODE=$?
+
+    if [ ${EXIT_CODE} -ne ${MYSQLD_RESTART_CODE} ]; then
+        echo "MySQL exited with code ${EXIT_CODE}."
+        break
+    fi
+done


### PR DESCRIPTION
This PR is a follow-up of PR https://github.com/canonical/charmed-mysql-snap/pull/85, moving the log file creation to the mysqld start-up script.

This is necessary for some of the MySQL Server 8.4 integration tests to pass, and it is a a better alternative than creating the file on the install hook (i.e. each snap service restart resets the log file). The `query.log` file was not needed.