### PR TITLE
[DPE-9477] Bump MySQL to 8.0.45

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: core22
-version: '8.0.44'
+version: '8.0.45'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -145,16 +145,16 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server=8.0.44-0ubuntu0.22.04.1
-      - mysql-router=8.0.44-0ubuntu0.22.04.1
-      - mysql-shell=8.0.44+dfsg-0ubuntu0.22.04.1~ppa2
+      - mysql-server=8.0.45-0ubuntu0.22.04.1
+      - mysql-router=8.0.45-0ubuntu0.22.04.1
+      - mysql-shell=8.0.45+dfsg-0ubuntu0.22.04.1~ppa1
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa2
-      - percona-xtrabackup=8.0.35-32-0ubuntu0.22.04.1~ppa1
-      - mysql-audit-log-filter-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
-      - mysql-audit-log-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
-      - mysql-auth-ldap-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
-      - mysql-binlog-utils-udf-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
+      - percona-xtrabackup=8.0.35-35-0ubuntu0.22.04.1~ppa1
+      - mysql-audit-log-filter-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-audit-log-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-auth-ldap-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-binlog-utils-udf-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
       - mysql-pitr-helper=2-0ubuntu0.22.04.1~ppa1
       - util-linux
     organize:


### PR DESCRIPTION
This PR updates charmed mysql snap to version 8.0.45.

---

Depends on:

- [MySQL Shell 8.0 PPA](https://launchpad.net/~data-platform/+archive/ubuntu/mysql-shell-8.0) to be updated by the server team.
- [MySQL Plugins 8.0 PPA](https://launchpad.net/~data-platform/+archive/ubuntu/mysql-server-plugins-8.0) to be updated by the server team.