### PR TITLE
[DPE-9478] Bump MySQL Shell to 8.4.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -146,7 +146,7 @@ parts:
     stage-packages:
       - mysql-server=8.4.7-0ubuntu0.24.04.1~ppa2
       - mysql-router=8.4.7-0ubuntu0.24.04.1~ppa2
-      - mysql-shell=8.4.7+dfsg-0ubuntu0.24.04.1~ppa1
+      - mysql-shell=8.4.8+dfsg-0ubuntu0.24.04.1~ppa1
       - prometheus-mysqld-exporter=0.16.0-0ubuntu0.24.04.1~ppa3
       - prometheus-mysqlrouter-exporter=6.0.0-0ubuntu0.24.04.1~ppa1
       - percona-xtrabackup=8.4.0-5-0ubuntu0.24.04.1~ppa1


### PR DESCRIPTION
This PR updates charmed mysql snap to version 8.4.8.

---

Depends on:

- [MySQL Shell 8.4 PPA](https://launchpad.net/~data-platform/+archive/ubuntu/mysql-shell-8.4) to be updated by the server team.
- [MySQL Plugins 8.4 PPA](https://launchpad.net/~data-platform/+archive/ubuntu/mysql-server-plugins-8.4) to be updated by the server team.