### PR TITLE
[MISC] 8.0 - Custom supervisor script

### DIFF
--- a/snap/local/start-mysqld.sh
+++ b/snap/local/start-mysqld.sh
@@ -1,12 +1,29 @@
 #!/bin/bash
 
-# For security measures, applications should not be run as sudo.
-# Execute mysqld_safe as the non-sudo user: snap-daemon
-# Note: group is set to root due to backups related intricacies.
-exec "${SNAP}/usr/bin/setpriv" \
-    --clear-groups \
-    --reuid snap_daemon \
-    --regid root \
-    -- \
-    "${SNAP}/usr/bin/mysqld_safe" \
-    --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf"
+# This script is designed to be a "supervisor process" for MySQL Server.
+# Such process is needed for it to be able to restart upon config changes.
+# Ref: https://dev.mysql.com/doc/refman/8.0/en/restart.html
+
+export MYSQLD_PARENT_PID=$$
+export MYSQLD_RESTART_CODE=16
+
+while true; do
+    # For security measures, applications should not be run as sudo.
+    # Execute mysqld as the non-sudo user: snap-daemon
+    # Note: group is set to root due to backups related intricacies.
+    exec "${SNAP}/usr/bin/setpriv" \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid root \
+        -- \
+        "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf" &
+
+    wait $!
+
+    EXIT_CODE=$?
+
+    if [ ${EXIT_CODE} -ne ${MYSQLD_RESTART_CODE} ]; then
+        echo "MySQL exited with code ${EXIT_CODE}."
+        break
+    fi
+done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: core22
-version: '8.0.44'
+version: '8.0.45'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -145,16 +145,16 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server=8.0.44-0ubuntu0.22.04.1
-      - mysql-router=8.0.44-0ubuntu0.22.04.1
-      - mysql-shell=8.0.44+dfsg-0ubuntu0.22.04.1~ppa2
+      - mysql-server=8.0.45-0ubuntu0.22.04.1
+      - mysql-router=8.0.45-0ubuntu0.22.04.1
+      - mysql-shell=8.0.45+dfsg-0ubuntu0.22.04.1~ppa1
       - prometheus-mysqld-exporter=0.14.0-0ubuntu0.22.04.1~ppa3
       - prometheus-mysqlrouter-exporter=5.0.1-0ubuntu0.22.04.1~ppa2
-      - percona-xtrabackup=8.0.35-32-0ubuntu0.22.04.1~ppa1
-      - mysql-audit-log-filter-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
-      - mysql-audit-log-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
-      - mysql-auth-ldap-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
-      - mysql-binlog-utils-udf-plugin=8.0.44+ds-0ubuntu0.22.04.1~ppa1
+      - percona-xtrabackup=8.0.35-35-0ubuntu0.22.04.1~ppa1
+      - mysql-audit-log-filter-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-audit-log-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-auth-ldap-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
+      - mysql-binlog-utils-udf-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
       - mysql-pitr-helper=2-0ubuntu0.22.04.1~ppa1
       - util-linux
     organize:


### PR DESCRIPTION
This PR defines a custom supervisor script to manage the `mysqld` process, moving away from `mysqld_safe`.

Previous attempts to move away from the deprecated `mysqld_safe` script were unsuccessful, because following the MySQL Restart page [guide](https://dev.mysql.com/doc/refman/8.0/en/restart.html) about how to define a custom supervisor process does not account for such supervisor process to be run, yet again, by another supervisor process (in our case, SystemD). For that to work, we need to run the binary as a background process within the script.

Running this script as a Snap service (i.e. SystemD service), does not require to trap signals, as SystemD is smart enough to track all PIDs started under a given service (see [KillMode](https://manpages.ubuntu.com/manpages/focal/man5/systemd.kill.5.html) default value).

---

Depends on PR https://github.com/canonical/charmed-mysql-snap/pull/87.