### PR TITLE
[DPE-9494] Remove initialization

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -47,8 +47,6 @@ sed -i "s:/etc/mysql:$MYSQL_ETC:g" $MYSQL_CONFIG
 echo "log_bin_index = $MYSQL_VAR_LIB/binlog.index" >> $MYSQLD_CONFIG
 echo "mysqlx_socket = $MYSQLD_VAR_RUN/mysqlx.sock" >> $MYSQLD_CONFIG
 
-$SNAP/usr/sbin/mysqld --initialize --datadir=$MYSQL_VAR_LIB --user=root
-
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root $SNAP_DATA/*
 chown -R 584788:root $SNAP_COMMON/*

--- a/snap/local/initialize-mysqld.sh
+++ b/snap/local/initialize-mysqld.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eo pipefail  # Exit on error
+
+exec "${SNAP}/usr/sbin/mysqld" --initialize "$@"

--- a/snap/local/initialize-mysqld.sh
+++ b/snap/local/initialize-mysqld.sh
@@ -2,4 +2,11 @@
 
 set -eo pipefail  # Exit on error
 
-exec "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf" --initialize "$@"
+# Run mysqld initialization as snap_daemon user (similar to start-mysqld.sh)
+# This ensures proper permissions from the start
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid root \
+    -- \
+    "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf" --initialize "$@"

--- a/snap/local/initialize-mysqld.sh
+++ b/snap/local/initialize-mysqld.sh
@@ -2,4 +2,4 @@
 
 set -eo pipefail  # Exit on error
 
-exec "${SNAP}/usr/sbin/mysqld" --initialize "$@"
+exec "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf" --initialize "$@"

--- a/snap/local/initialize-mysqld.sh
+++ b/snap/local/initialize-mysqld.sh
@@ -7,6 +7,6 @@ set -eo pipefail  # Exit on error
 exec "${SNAP}/usr/bin/setpriv" \
     --clear-groups \
     --reuid snap_daemon \
-    --regid root \
+    --regid snap_daemon \
     -- \
     "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf" --initialize "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,6 +87,8 @@ apps:
     plugs:
       - network
       - network-bind
+  mysqld-initialize:
+    command: initialize-mysqld.sh
   mysqlsh:
     command: run-mysqlsh.sh
     plugs:

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -21,6 +21,8 @@ EOF
 
 chown -R snap_daemon ${CURRENT}/etc/mysql/mysql.conf.d/*
 
+charmed-mysql.mysqld-initialize
+
 snap start charmed-mysql.mysqld
 sleep 2
 snap restart charmed-mysql.mysqld

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -37,7 +37,7 @@ def test_all_apps():
             "xtrabackup": "--version",
         }
 
-        sudo = ["mysqlrouter", "mysqlsh", "mysqlrouter-passwd"]
+        sudo = ["mysqlrouter", "mysqlsh", "mysqlrouter-passwd", "mysqld-initialize"]
         # pitr helper requires s3 credentials
         skip = ["mysql-pitr-helper"]
 
@@ -82,6 +82,11 @@ def test_all_services():
         )
 
         skip = ["mysqlrouter-service", "mysql-pitr-helper-collector"]
+
+        subprocess.run(
+            f"sudo charmed-mysql.mysqld-initialize --datadir /var/snap/{snapcraft['name']}/common/var/lib/mysql".split(),
+            check=True,
+        )
 
         subprocess.run(
             f"sudo snap start {snapcraft['name']}.mysqlrouter-service".split(),


### PR DESCRIPTION
`mysqld --initialize` has been present in the charmed snap since the first commit. However, https://github.com/canonical/mysql-operators/pull/87 surfaced the need to harmonize how the K8s and VM substrates do initialization.

The charmed rock had initialization since https://github.com/canonical/charmed-mysql-rock/pull/6, but https://github.com/canonical/charmed-mysql-rock/pull/42#discussion_r1658288677 removed that part of the code because it was determined that it didn't have any effect.