### PR TITLE
[DPE-9537] 8.0 - Bump PITR helper to v6

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -155,7 +155,7 @@ parts:
       - mysql-audit-log-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
       - mysql-auth-ldap-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
       - mysql-binlog-utils-udf-plugin=8.0.45+ds-0ubuntu0.22.04.1~ppa1
-      - mysql-pitr-helper=2-0ubuntu0.22.04.1~ppa1
+      - mysql-pitr-helper=6-0ubuntu0.22.04.1
       - util-linux
     organize:
       usr/share/doc/mysql-server/copyright: licenses/COPYRIGHT-mysql-server


### PR DESCRIPTION
This PR bumps the version of the PITR helper to version 6, after it was updated from upstream.