### PR TITLE
[DPE-9537] 8.4 - Bump PITR helper to v6

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -154,7 +154,7 @@ parts:
       - mysql-audit-log-plugin=8.4.7+ds-0ubuntu0.24.04.3~ppa1
       - mysql-auth-ldap-plugin=8.4.7+ds-0ubuntu0.24.04.3~ppa1
       - mysql-binlog-utils-udf-plugin=8.4.7+ds-0ubuntu0.24.04.3~ppa1
-      - mysql-pitr-helper=2-0ubuntu0.24.04.2~ppa1
+      - mysql-pitr-helper=6-0ubuntu0.24.04.1
       - util-linux
     organize:
       usr/share/doc/mysql-server/copyright: licenses/COPYRIGHT-mysql-server


### PR DESCRIPTION
This PR bumps the version of the PITR helper to version 6, after it was updated from upstream.