### PR TITLE
[MISC] Restore root GID for `mysqld --initialize`

### DIFF
--- a/snap/local/initialize-mysqld.sh
+++ b/snap/local/initialize-mysqld.sh
@@ -7,6 +7,6 @@ set -eo pipefail  # Exit on error
 exec "${SNAP}/usr/bin/setpriv" \
     --clear-groups \
     --reuid snap_daemon \
-    --regid snap_daemon \
+    --regid root \
     -- \
     "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP_DATA}/etc/mysql/mysql.cnf" --initialize "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,7 +156,7 @@ parts:
       - mysql-audit-log-plugin=8.4.7+ds-0ubuntu0.24.04.3~ppa1
       - mysql-auth-ldap-plugin=8.4.7+ds-0ubuntu0.24.04.3~ppa1
       - mysql-binlog-utils-udf-plugin=8.4.7+ds-0ubuntu0.24.04.3~ppa1
-      - mysql-pitr-helper=6-0ubuntu0.24.04.1
+      - mysql-pitr-helper=2-0ubuntu0.24.04.2~ppa1
       - util-linux
     organize:
       usr/share/doc/mysql-server/copyright: licenses/COPYRIGHT-mysql-server


### PR DESCRIPTION
Otherwise, XtraBackup cannot traverse some directories (`[MY-012609] [InnoDB] Failed to walk directory '.../mysql'`). See https://github.com/canonical/mysql-operators/pull/177.