### PR TITLE
[MISC] 8.0 - Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ on:
   push:
     branches:
       - 8.0/edge
+    paths:
+      - snap/**
+  workflow_dispatch:
 
 jobs:
   build:
@@ -22,9 +25,10 @@ jobs:
       - build
     uses: canonical/data-platform-workflows/.github/workflows/release_snap_edge.yaml@v46.0.0
     with:
-      track: 8.0
+      track: '8.0'
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
     permissions:
+      actions: read    # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tags


### PR DESCRIPTION
This PR is a follow-up to https://github.com/canonical/charmed-mysql-snap/pull/98, where the release workflow permissions were not properly updated.

See [CI run](https://github.com/canonical/charmed-mysql-snap/actions/runs/24247479201).