### PR TITLE
[DPE-9970] 8.4 - Enable 26.04 version check

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04
+    - ubuntu-26.04-arm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,29 +16,28 @@ jobs:
     permissions:
       contents: read
 
-#  TODO: Uncomment when GitHub offers 26.04 runners
-#  check-version:
-#    name: Check version
-#    runs-on: ubuntu-26.04
-#    timeout-minutes: 15
-#    permissions: {}
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v6
-#        with:
-#          persist-credentials: false
-#      - name: Install yq
-#        run: sudo snap install yq
-#      - name: Compare versions
-#        run: |
-#          SNAP_VERSION=$(yq .version snap/snapcraft.yaml)
-#          APT_VERSION=$(apt-cache show mysql-server | awk '/Version: /{print $2; exit}' | cut --delimiter "-" --fields 1)
-#          if [ "$SNAP_VERSION" != "$APT_VERSION" ]; then
-#              echo "VERSION MISMATCH DETECTED"
-#              echo "Snap version: $SNAP_VERSION"
-#              echo "APT version: $APT_VERSION"
-#              exit 1
-#          fi
+  check-version:
+    name: Check version
+    runs-on: ubuntu-26.04
+    timeout-minutes: 15
+    permissions: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install yq
+        run: sudo snap install yq
+      - name: Compare versions
+        run: |
+          SNAP_VERSION=$(yq .version snap/snapcraft.yaml)
+          APT_VERSION=$(apt-cache show mysql-server | awk '/Version: /{print $2; exit}' | cut --delimiter "-" --fields 1)
+          if [ "$SNAP_VERSION" != "$APT_VERSION" ]; then
+              echo "VERSION MISMATCH DETECTED"
+              echo "Snap version: $SNAP_VERSION"
+              echo "APT version: $APT_VERSION"
+              exit 1
+          fi
 
   build:
     name: Build snap
@@ -56,7 +55,7 @@ jobs:
     permissions: {}
     needs:
       - lint
-      # - check-version
+      - check-version
       - build
     steps:
       - name: Checkout
@@ -80,7 +79,7 @@ jobs:
     permissions: {}
     needs:
       - lint
-      # - check-version
+      - check-version
       - build
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,6 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49
-    with:
-      snapcraft-snap-channel: latest/candidate
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,6 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49
-    with:
-      snapcraft-snap-channel: latest/candidate
     permissions:
       actions: read
       contents: read

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: core26
-version: '8.4.8'
+version: '8.4.9'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -123,16 +123,16 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server=8.4.8-0ubuntu1
-      - mysql-router=8.4.8-0ubuntu1
+      - mysql-server=8.4.9-0ubuntu0.26.04.1
+      - mysql-router=8.4.9-0ubuntu0.26.04.1
       - mysql-shell=8.4.8+dfsg-0ubuntu1
       - prometheus-mysqld-exporter=0.18.0-1
       - prometheus-mysqlrouter-exporter=6.0.1-1
       - percona-xtrabackup=8.4.0-5-0ubuntu1
-      - mysql-audit-log-filter-plugin=8.4.8+ds-0ubuntu0.26.04.1~ppa1
-      - mysql-audit-log-plugin=8.4.8+ds-0ubuntu0.26.04.1~ppa1
-      - mysql-auth-ldap-plugin=8.4.8+ds-0ubuntu0.26.04.1~ppa1
-      - mysql-binlog-utils-udf-plugin=8.4.8+ds-0ubuntu0.26.04.1~ppa1
+      - mysql-audit-log-filter-plugin=8.4.8+ds-0ubuntu0.26.04.2~ppa1
+      - mysql-audit-log-plugin=8.4.8+ds-0ubuntu0.26.04.2~ppa1
+      - mysql-auth-ldap-plugin=8.4.8+ds-0ubuntu0.26.04.2~ppa1
+      - mysql-binlog-utils-udf-plugin=8.4.8+ds-0ubuntu0.26.04.2~ppa1
       - util-linux
     organize:
       usr/share/doc/mysql-server/copyright: licenses/COPYRIGHT-mysql-server


### PR DESCRIPTION
This PR enables back the Ubuntu 26.04 MySQL binaries version check (disabled given the lack of GH runners).

### Additional changes:
- MySQL Server bumped to `8.4.9`.
- MySQL Router bumped to `8.4.9`.