### PR TITLE
[MISC] 8.4 - Bump MySQL to version 8.4.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,11 +10,28 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: Lint
+  lint-workflows:
+    name: Lint .github/workflows/
     uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v49
     permissions:
       contents: read
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install tox & poetry
+        run: |
+          pipx install tox
+          pipx install poetry
+      - name: tox run -e lint
+        run: tox run -e lint
 
   check-version:
     name: Check version
@@ -52,6 +69,7 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     needs:
+      - lint-workflows
       - lint
       - check-version
       - build
@@ -76,6 +94,7 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     needs:
+      - lint-workflows
       - lint
       - check-version
       - build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
           persist-credentials: false
       - name: Install yq
         run: sudo snap install yq
+      - name: Update package metadata
+        run: sudo apt update
       - name: Compare versions
         run: |
           SNAP_VERSION=$(yq .version snap/snapcraft.yaml)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mysql
 base: core26
-version: '8.4.9'
+version: '8.4.10'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -123,8 +123,8 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server=8.4.9-0ubuntu0.26.04.1
-      - mysql-router=8.4.9-0ubuntu0.26.04.1
+      - mysql-server=8.4.10-0ubuntu0.26.04.1
+      - mysql-router=8.4.10-0ubuntu0.26.04.1
       - mysql-shell=8.4.8+dfsg-0ubuntu1
       - prometheus-mysqld-exporter=0.18.0-1
       - prometheus-mysqlrouter-exporter=6.0.1-1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,8 @@ system-usernames:
 
 package-repositories:
   - type: apt
+    ppa: data-platform/mysql-shell-8.4
+  - type: apt
     ppa: data-platform/mysql-server-plugins-8.4
 
 layout:
@@ -125,7 +127,7 @@ parts:
     stage-packages:
       - mysql-server=8.4.10-0ubuntu0.26.04.1
       - mysql-router=8.4.10-0ubuntu0.26.04.1
-      - mysql-shell=8.4.8+dfsg-0ubuntu1
+      - mysql-shell=8.4.10+dfsg-0ubuntu0.26.04.1~ppa1
       - prometheus-mysqld-exporter=0.18.0-1
       - prometheus-mysqlrouter-exporter=6.0.1-1
       - percona-xtrabackup=8.4.0-5-0ubuntu1


### PR DESCRIPTION
This PR bumps the MySQL 8.4 binaries to its latest version: 8.4.10.

### Additional changes
- Decouple _lint_ and _lint-workflows_ steps similarly to what the `8.0/edge` branch did (see [code](https://github.com/canonical/charmed-mysql-snap/blob/a7754b2f2da0b167e0ff693ec75181ce996c33cd/.github/workflows/ci.yaml#L13-L34)).